### PR TITLE
feat: RAGシステム4種の広域対応 + 中国語混入対策 (Phase 9-B #3)

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -137,6 +137,15 @@ from .structured_rag_system import (
     create_structured_rag_system,
 )
 
+# Phase 9-B: agent_tools エクスポート
+from .agent_tools import (
+    set_global_pois,
+    set_global_pois_multi_area,
+    get_global_pois,
+    format_tool_output_japanese,
+    get_all_tools,
+)
+
 # バージョン情報
-__version__ = "0.9.2"
-__phase__ = "Phase 9-B: Multi-Area Core Modules"
+__version__ = "0.9.3"
+__phase__ = "Phase 9-B: Multi-Area RAG Systems"

--- a/src/adaptive_rag_system.py
+++ b/src/adaptive_rag_system.py
@@ -20,10 +20,12 @@ try:
     from .structured_rag_system import StructuredRAGSystem, QuestionAnalysis, analyze_question
     from .graph_rag_system import GraphRAGSystem
     from .graph_builder import POIGraphBuilder
+    from .geo_utils import SHIBUYA_STATION
 except ImportError:
     from structured_rag_system import StructuredRAGSystem, QuestionAnalysis, analyze_question
     from graph_rag_system import GraphRAGSystem
     from graph_builder import POIGraphBuilder
+    from geo_utils import SHIBUYA_STATION
 
 
 @dataclass
@@ -65,6 +67,7 @@ class AdaptiveRAGSystem:
         tokenizer,
         vectorstore,
         all_pois: List[Dict[str, Any]],
+        areas_config: Optional[Dict[str, Any]] = None,
         include_extended_edges: bool = True,
         verbose: bool = False
     ):
@@ -74,6 +77,7 @@ class AdaptiveRAGSystem:
             tokenizer: トークナイザー
             vectorstore: LangChain ChromaDBベクトルストア
             all_pois: 全POIデータ
+            areas_config: エリア設定辞書（None時は渋谷単一エリア）
             include_extended_edges: 拡張エッジを含むか（GraphRAG用）
             verbose: 詳細ログを出力するか
         """
@@ -81,6 +85,7 @@ class AdaptiveRAGSystem:
         self.tokenizer = tokenizer
         self.vectorstore = vectorstore
         self.all_pois = all_pois
+        self.areas_config = areas_config
         self.include_extended_edges = include_extended_edges
         self.verbose = verbose
 
@@ -107,6 +112,7 @@ class AdaptiveRAGSystem:
                 tokenizer=self.tokenizer,
                 vectorstore=self.vectorstore,
                 all_pois=self.all_pois,
+                areas_config=self.areas_config,
                 debug=self.verbose
             )
         return self._structured_rag
@@ -116,15 +122,21 @@ class AdaptiveRAGSystem:
         """GraphRAGシステム（遅延ロード）"""
         if self._graph_rag is None:
             self._log("GraphRAGシステムを初期化中...")
-            # POIGraphBuilderでグラフを構築
-            builder = POIGraphBuilder()
-            graph = builder.build_graph(
-                self.all_pois,
-                include_extended_edges=self.include_extended_edges,
-                verbose=self.verbose
-            )
-            # 構築済みグラフをGraphRAGSystemに渡す
-            self._graph_rag = GraphRAGSystem(graph_or_pois=graph)
+            if self.areas_config and len(self.areas_config) > 1:
+                # 広域対応: エリア別グラフ構築
+                self._graph_rag = GraphRAGSystem(
+                    areas_config=self.areas_config,
+                    all_pois=self.all_pois
+                )
+            else:
+                # 後方互換: 単一グラフ構築
+                builder = POIGraphBuilder()
+                graph = builder.build_graph(
+                    self.all_pois,
+                    include_extended_edges=self.include_extended_edges,
+                    verbose=self.verbose
+                )
+                self._graph_rag = GraphRAGSystem(graph_or_pois=graph)
             # GraphRAGにもモデル・トークナイザーを設定
             self._graph_rag.model = self.model
             self._graph_rag.tokenizer = self.tokenizer
@@ -205,7 +217,17 @@ class AdaptiveRAGSystem:
         """
         import torch
 
-        system_prompt = """あなたは渋谷エリアの地理情報に詳しいアシスタントです。
+        if self.areas_config and len(self.areas_config) > 1:
+            area_names = "、".join(
+                info.get("name", key) for key, info in self.areas_config.items()
+            )
+            system_prompt = f"""あなたは東京都内の主要駅周辺エリア（{area_names}）の地理情報に詳しいアシスタントです。
+提供された情報に基づいて、正確かつ簡潔に回答してください。
+座標情報がある場合は必ず含めてください。
+数値データがある場合は具体的な数字を使って回答してください。
+情報がない場合は「情報がありません」と正直に回答してください。"""
+        else:
+            system_prompt = """あなたは渋谷エリアの地理情報に詳しいアシスタントです。
 提供された情報に基づいて、正確かつ簡潔に回答してください。
 座標情報がある場合は必ず含めてください。
 数値データがある場合は具体的な数字を使って回答してください。

--- a/src/agent_prompts.py
+++ b/src/agent_prompts.py
@@ -14,23 +14,31 @@ from typing import List, Dict, Any
 # システムプロンプト
 # =============================================================================
 
-AGENT_SYSTEM_PROMPT = """あなたは渋谷駅周辺の地理空間POI（Point of Interest）情報に精通したエージェントです。
+AGENT_SYSTEM_PROMPT = """あなたは東京都内の主要駅周辺（渋谷、新宿、池袋、東京）の地理空間POI（Point of Interest）情報に精通したエージェントです。
 ユーザーの質問に答えるため、利用可能なツールを駆使して正確な情報を収集し、回答を生成してください。
 
 **重要: すべての回答は必ず日本語で行ってください。中国語や英語で回答してはいけません。**
 
+# 利用可能なエリア
+
+- shibuya: 渋谷駅周辺
+- shinjuku: 新宿駅周辺
+- ikebukuro: 池袋駅周辺
+- tokyo: 東京駅周辺
+
 # あなたの役割
 
-1. **質問理解**: ユーザーの質問を分析し、何を求めているか正確に理解する
-2. **計画立案**: 質問に答えるために必要なツールと実行順序を決定する
-3. **ツール実行**: 適切なツールを選択し、正しいパラメータで実行する
-4. **結果統合**: 複数のツール実行結果を統合し、包括的な回答を生成する
-5. **検証**: 回答が質問に適切に答えているか確認し、必要に応じて追加検索する
+1. **エリア特定**: 質問文から対象エリアを特定する（渋谷、新宿、池袋、東京）
+2. **質問理解**: ユーザーの質問を分析し、何を求めているか正確に理解する
+3. **計画立案**: 質問に答えるために必要なツールと実行順序を決定する
+4. **ツール実行**: 適切なツールを選択し、正しいパラメータで実行する
+5. **結果統合**: 複数のツール実行結果を統合し、包括的な回答を生成する
+6. **検証**: 回答が質問に適切に答えているか確認し、必要に応じて追加検索する
 
 # 利用可能なツール群
 
 ## 空間計算ツール
-- `tool_get_nearest_pois`: 渋谷駅から最も近いPOIを検索
+- `tool_get_nearest_pois`: 指定エリアの駅から最も近いPOIを検索
 - `tool_count_pois_in_radius`: 指定半径内のPOI件数を集計
 - `tool_compare_radius`: 異なる半径での件数比較（感度分析）
 - `tool_analyze_sensitivity`: 複数半径での詳細な感度分析
@@ -50,15 +58,16 @@ AGENT_SYSTEM_PROMPT = """あなたは渋谷駅周辺の地理空間POI（Point o
 
 # 実行ガイドライン
 
-1. **段階的思考**: 一度に全てを実行せず、段階的にツールを実行して情報を収集する
-2. **適切なツール選択**: 質問のタイプに応じて最も適したツールを選択する
+1. **エリア特定が最優先**: 質問文に「新宿」「池袋」「東京駅」などのキーワードがあれば該当エリアを対象にする。エリアが不明な場合は全エリアを対象にする
+2. **段階的思考**: 一度に全てを実行せず、段階的にツールを実行して情報を収集する
+3. **適切なツール選択**: 質問のタイプに応じて最も適したツールを選択する
    - 「最も近い」「最寄り」→ `tool_get_nearest_pois`
    - 「何件」「いくつ」→ `tool_count_pois_in_radius` または `tool_count_by_category`
    - 「東西比較」→ `tool_compare_east_west`
    - 「半径を変えると」「範囲を広げると」→ `tool_compare_radius` または `tool_analyze_sensitivity`
-3. **パラメータ検証**: ツールを呼び出す前にパラメータが適切か確認する
-4. **結果検証**: ツール実行結果が期待通りか確認し、必要に応じて再実行する
-5. **エラーハンドリング**: エラーが発生した場合は代替手段を試みる
+4. **パラメータ検証**: ツールを呼び出す前にパラメータが適切か確認する
+5. **結果検証**: ツール実行結果が期待通りか確認し、必要に応じて再実行する
+6. **エラーハンドリング**: エラーが発生した場合は代替手段を試みる
 
 # 回答形式
 
@@ -71,7 +80,7 @@ AGENT_SYSTEM_PROMPT = """あなたは渋谷駅周辺の地理空間POI（Point o
 
 # 注意事項
 
-- 渋谷駅の座標は固定 (35.658034, 139.701636)
+- 各エリアの駅座標は各ツールが自動的に管理する
 - 距離はメートル単位で表示
 - カテゴリは部分一致で検索可能（例: "カフェ"で"飲食店/カフェ"が該当）
 - 最大10回のツール実行まで（無限ループ防止）
@@ -81,24 +90,24 @@ AGENT_SYSTEM_PROMPT = """あなたは渋谷駅周辺の地理空間POI（Point o
 """
 
 
-REACT_PROMPT_TEMPLATE = """Question: {question}
+REACT_PROMPT_TEMPLATE = """質問: {question}
 
 あなたは以下のフォーマットで思考と行動を繰り返してください：
 
-Thought: 質問に答えるために何をすべきか考える
-Action: 実行するツール名
-Action Input: ツールへの入力（JSON形式）
-Observation: ツールからの出力
+思考: 質問に答えるために何をすべきか考える
+行動: 実行するツール名
+行動入力: ツールへの入力（JSON形式）
+観察結果: ツールからの出力（日本語テキスト）
 
-... (このThought/Action/Action Input/Observationを必要なだけ繰り返す)
+... (この思考/行動/行動入力/観察結果を必要なだけ繰り返す)
 
-Thought: 十分な情報が集まったので最終回答を生成できる
-Final Answer: ユーザーへの最終回答
+思考: 十分な情報が集まったので最終回答を生成できる
+最終回答: ユーザーへの最終回答（必ず日本語で）
 
 それでは始めてください。
 
-Question: {question}
-Thought:"""
+質問: {question}
+思考:"""
 
 
 PLANNING_PROMPT_TEMPLATE = """以下の質問に答えるための実行計画を立ててください。
@@ -326,23 +335,25 @@ def generate_tools_description() -> str:
 利用可能なツール：
 
 【空間計算ツール】
-- tool_get_nearest_pois(category, top_n): 最寄りPOI検索
-- tool_count_pois_in_radius(radius_m, category): 半径内POI件数
-- tool_compare_radius(radius1_m, radius2_m, category): 半径比較
-- tool_analyze_sensitivity(category, radii): 詳細感度分析
-- tool_filter_by_area(radius_m, category): エリア内POIリスト
+- tool_get_nearest_pois(area, category, top_n): 指定エリアの最寄りPOI検索
+- tool_count_pois_in_radius(area, radius_m, category): 半径内POI件数
+- tool_compare_radius(area, radius1_m, radius2_m, category): 半径比較
+- tool_analyze_sensitivity(area, category, radii): 詳細感度分析
+- tool_filter_by_area(area, radius_m, category): エリア内POIリスト
 - tool_calculate_distance(poi_name1, poi_name2): 2点間距離
 
 【比較・集計ツール】
-- tool_compare_east_west(category): 東西比較
-- tool_compare_north_south(category): 南北比較
-- tool_count_by_category(categories): カテゴリ別集計
-- tool_get_top_categories(top_n): カテゴリランキング
-- tool_analyze_category_by_direction(category): 方向別分析
+- tool_compare_east_west(area, category): 東西比較
+- tool_compare_north_south(area, category): 南北比較
+- tool_count_by_category(area, categories): カテゴリ別集計
+- tool_get_top_categories(area, top_n): カテゴリランキング
+- tool_analyze_category_by_direction(area, category): 方向別分析
 
 【検索ツール】
 - tool_vector_search(query, k): セマンティック検索
 - tool_find_pois_by_keyword(keyword): キーワード検索
+
+areaの指定: "shibuya", "shinjuku", "ikebukuro", "tokyo" のいずれか。省略時は全エリア対象。
 """
 
 
@@ -356,21 +367,41 @@ def test_prompts():
     print("agent_prompts.py 動作確認")
     print("=" * 60)
 
-    question = "渋谷駅から最も近いカフェは？"
+    # Phase 9-B: 広域対応テスト
+    test_cases = [
+        "渋谷駅から最も近いカフェは？",
+        "新宿駅周辺のレストランを教えてください",
+        "池袋と渋谷でカフェが多いのはどちら？",
+    ]
 
-    print("\n--- ReActプロンプト ---")
-    print(format_react_prompt(question))
+    for question in test_cases:
+        print(f"\n--- ReActプロンプト: {question} ---")
+        prompt = format_react_prompt(question)
+        # 日本語メタ言語が含まれることを確認
+        assert "思考:" in prompt, "ReActプロンプトに日本語メタ言語「思考:」がありません"
+        assert "行動:" in prompt, "ReActプロンプトに日本語メタ言語「行動:」がありません"
+        assert "最終回答:" in prompt, "ReActプロンプトに日本語メタ言語「最終回答:」がありません"
+        print(prompt[:200] + "...")
+
+    # システムプロンプトの汎用化確認
+    # 「渋谷駅周辺の地理空間POI」のような単一エリア固有記述が除去されていることを確認
+    # 「shibuya: 渋谷駅周辺」のようなエリア一覧内の記述はOK
+    assert "渋谷駅周辺の地理空間" not in AGENT_SYSTEM_PROMPT, "システムプロンプトに渋谷固有の記述が残っています"
+    assert "東京都内" in AGENT_SYSTEM_PROMPT, "システムプロンプトが汎用化されていません"
+    assert "新宿" in AGENT_SYSTEM_PROMPT, "システムプロンプトに新宿エリアの記述がありません"
+    assert "池袋" in AGENT_SYSTEM_PROMPT, "システムプロンプトに池袋エリアの記述がありません"
+
+    # ツール説明にarea引数があることを確認
+    tools_desc = generate_tools_description()
+    assert "area" in tools_desc, "ツール説明にarea引数がありません"
 
     print("\n--- プランニングプロンプト ---")
-    print(format_planning_prompt(question))
-
-    print("\n--- 質問タイプ別プロンプト（proximity） ---")
-    print(get_question_type_prompt("proximity", question))
+    print(format_planning_prompt(test_cases[0])[:200] + "...")
 
     print("\n--- ツール説明 ---")
     print(generate_tools_description())
 
-    print("\n✅ agent_prompts.py 動作確認完了")
+    print("\n✅ agent_prompts.py 動作確認完了（広域対応 + ReAct日本語化）")
 
 
 if __name__ == "__main__":

--- a/src/agent_tools.py
+++ b/src/agent_tools.py
@@ -21,9 +21,12 @@ try:
         compare_by_radius,
         haversine_distance,
         SHIBUYA_STATION,
+        STATIONS,
+        AREA_STATION_MAP,
         filter_east_side,
         filter_west_side,
-        analyze_radius_sensitivity
+        analyze_radius_sensitivity,
+        detect_target_area,
     )
     from .aggregator import (
         count_by_category,
@@ -41,9 +44,12 @@ except ImportError:
         compare_by_radius,
         haversine_distance,
         SHIBUYA_STATION,
+        STATIONS,
+        AREA_STATION_MAP,
         filter_east_side,
         filter_west_side,
-        analyze_radius_sensitivity
+        analyze_radius_sensitivity,
+        detect_target_area,
     )
     from aggregator import (
         count_by_category,
@@ -60,11 +66,13 @@ except ImportError:
 # =============================================================================
 
 _GLOBAL_POIS: List[Dict[str, Any]] = []
+_GLOBAL_POIS_BY_AREA: Dict[str, List[Dict[str, Any]]] = {}
+_GLOBAL_AREAS_CONFIG: Dict[str, Any] = {}
 
 
 def set_global_pois(pois: List[Dict[str, Any]]) -> None:
     """
-    グローバルPOIデータを設定
+    グローバルPOIデータを設定（後方互換）
 
     Args:
         pois: POIデータのリスト（空間情報付き）
@@ -73,9 +81,246 @@ def set_global_pois(pois: List[Dict[str, Any]]) -> None:
     _GLOBAL_POIS = pois
 
 
-def get_global_pois() -> List[Dict[str, Any]]:
-    """グローバルPOIデータを取得"""
+def set_global_pois_multi_area(
+    pois: List[Dict[str, Any]],
+    areas_config: Dict[str, Any]
+) -> None:
+    """
+    複数エリアのPOIデータを設定
+
+    Args:
+        pois: 全エリアのPOIデータリスト（空間情報付き）
+        areas_config: エリア設定辞書
+    """
+    global _GLOBAL_POIS, _GLOBAL_POIS_BY_AREA, _GLOBAL_AREAS_CONFIG
+    _GLOBAL_POIS = pois
+    _GLOBAL_AREAS_CONFIG = areas_config
+    _GLOBAL_POIS_BY_AREA = {}
+    for poi in pois:
+        area_key = (poi.get("area_key")
+                     or poi.get("metadata", {}).get("area_key", "shibuya"))
+        _GLOBAL_POIS_BY_AREA.setdefault(area_key, []).append(poi)
+
+
+def get_global_pois(area: Optional[str] = None) -> List[Dict[str, Any]]:
+    """
+    グローバルPOIデータを取得
+
+    Args:
+        area: エリアキー。指定時はそのエリアのPOIのみ返す。
+              None時は全POIを返す。
+
+    Returns:
+        POIリスト
+    """
+    if area and area in _GLOBAL_POIS_BY_AREA:
+        return _GLOBAL_POIS_BY_AREA[area]
     return _GLOBAL_POIS
+
+
+def _get_area_station(area: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    """エリアキーから基準駅情報を取得"""
+    if area and area in _GLOBAL_AREAS_CONFIG:
+        return _GLOBAL_AREAS_CONFIG[area].get("station")
+    if area and area in AREA_STATION_MAP:
+        station_name = AREA_STATION_MAP[area]
+        return STATIONS.get(station_name)
+    return None
+
+
+# =============================================================================
+# ツール出力の日本語自然文変換（中国語混入対策）
+# =============================================================================
+
+def format_tool_output_japanese(tool_name: str, output: Any) -> str:
+    """
+    ツール出力をJSON形式から日本語自然文に変換する
+
+    Phase 9の中国語混入問題への対策。LLMにはJSON構造ではなく
+    日本語テキストとしてツール結果を渡す。
+
+    Args:
+        tool_name: ツール名
+        output: ツール出力（dict or str）
+
+    Returns:
+        日本語自然文テキスト
+    """
+    # 文字列の場合はJSONパースを試みる
+    if isinstance(output, str):
+        try:
+            output = json.loads(output)
+        except (json.JSONDecodeError, TypeError):
+            return output
+
+    if not isinstance(output, dict):
+        return str(output)
+
+    # エラーの場合
+    if "error" in output:
+        return f"エラー: {output['error']}"
+
+    if tool_name == "tool_get_nearest_pois":
+        category = output.get("category", "全て")
+        count = output.get("count", 0)
+        lines = [f"{category}の検索結果（{count}件）:"]
+        for poi in output.get("pois", []):
+            name = poi.get("name", "不明")
+            direction = poi.get("direction", "不明")
+            distance = poi.get("distance_m", "不明")
+            if isinstance(distance, (int, float)):
+                lines.append(f"  - {name}: 駅から{direction}方向に{distance:.1f}メートル")
+            else:
+                lines.append(f"  - {name}: 駅から{direction}方向に{distance}メートル")
+        return "\n".join(lines)
+
+    elif tool_name == "tool_count_pois_in_radius":
+        radius = output.get("radius_m", "不明")
+        category = output.get("category", "全て")
+        count = output.get("count", 0)
+        return f"半径{radius}メートル以内の{category}は{count}件です。"
+
+    elif tool_name == "tool_compare_radius":
+        r1 = output.get("radius1_m", "不明")
+        r2 = output.get("radius2_m", "不明")
+        c1 = output.get("count1", 0)
+        c2 = output.get("count2", 0)
+        category = output.get("category", "全て")
+        diff = output.get("difference", c2 - c1 if isinstance(c1, int) and isinstance(c2, int) else "不明")
+        summary = output.get("summary_jp", "")
+        if summary:
+            return summary
+        return (f"{category}の半径比較: {r1}m以内は{c1}件、{r2}m以内は{c2}件"
+                f"（差: {diff}件）。")
+
+    elif tool_name == "tool_analyze_sensitivity":
+        lines = ["感度分析結果:"]
+        if isinstance(output, dict):
+            for key, value in output.items():
+                if isinstance(value, dict):
+                    lines.append(f"  半径{key}: {value}")
+                else:
+                    lines.append(f"  {key}: {value}")
+        return "\n".join(lines)
+
+    elif tool_name == "tool_filter_by_area":
+        radius = output.get("radius_m", "不明")
+        category = output.get("category", "全て")
+        count = output.get("count", 0)
+        lines = [f"半径{radius}メートル以内の{category}（{count}件）:"]
+        for poi in output.get("pois", [])[:10]:
+            name = poi.get("name", "不明")
+            distance = poi.get("distance_m", "不明")
+            direction = poi.get("direction", "不明")
+            lines.append(f"  - {name}: {direction}方向に{distance}メートル")
+        return "\n".join(lines)
+
+    elif tool_name == "tool_calculate_distance":
+        poi1 = output.get("poi1", {}).get("name", "不明")
+        poi2 = output.get("poi2", {}).get("name", "不明")
+        distance = output.get("distance_m", "不明")
+        return f"{poi1}から{poi2}までの距離は{distance}メートルです。"
+
+    elif tool_name == "tool_compare_east_west":
+        category = output.get("category", "全て")
+        east = output.get("east_count", 0)
+        west = output.get("west_count", 0)
+        summary = output.get("summary_jp", "")
+        if summary:
+            return summary
+        return f"{category}の東西比較: 東側{east}件、西側{west}件。"
+
+    elif tool_name == "tool_compare_north_south":
+        category = output.get("category", "全て")
+        north = output.get("north_count", 0)
+        south = output.get("south_count", 0)
+        summary = output.get("summary_jp", "")
+        if summary:
+            return summary
+        return f"{category}の南北比較: 北側{north}件、南側{south}件。"
+
+    elif tool_name == "tool_count_by_category":
+        lines = ["カテゴリ別集計:"]
+        for cat, count in output.items():
+            lines.append(f"  - {cat}: {count}件")
+        return "\n".join(lines)
+
+    elif tool_name == "tool_get_top_categories":
+        top_n = output.get("top_n", 5)
+        lines = [f"カテゴリランキング（上位{top_n}件）:"]
+        for cat_info in output.get("categories", []):
+            rank = cat_info.get("rank", "")
+            category = cat_info.get("category", "不明")
+            count = cat_info.get("count", 0)
+            lines.append(f"  {rank}位: {category}（{count}件）")
+        return "\n".join(lines)
+
+    elif tool_name == "tool_analyze_category_by_direction":
+        lines = ["方向別分析:"]
+        for key, value in output.items():
+            lines.append(f"  {key}: {value}")
+        return "\n".join(lines)
+
+    elif tool_name == "tool_vector_search":
+        query = output.get("query", "")
+        count = output.get("count", 0)
+        lines = [f"「{query}」の検索結果（{count}件）:"]
+        for poi in output.get("pois", []):
+            name = poi.get("name", "不明")
+            category = poi.get("category", "不明")
+            lines.append(f"  - {name}（{category}）")
+        return "\n".join(lines)
+
+    elif tool_name == "tool_find_pois_by_keyword":
+        keyword = output.get("keyword", "")
+        count = output.get("count", 0)
+        lines = [f"「{keyword}」のキーワード検索結果（{count}件）:"]
+        for poi in output.get("pois", [])[:10]:
+            name = poi.get("name", "不明")
+            category = poi.get("category", "不明")
+            lines.append(f"  - {name}（{category}）")
+        return "\n".join(lines)
+
+    elif tool_name == "tool_find_nearby_similar_pois":
+        origin = output.get("origin_poi", "不明")
+        count = output.get("count", 0)
+        lines = [f"{origin}の近くにある同カテゴリPOI（{count}件）:"]
+        for poi in output.get("nearby_pois", []):
+            name = poi.get("name", "不明")
+            distance = poi.get("distance_m", "不明")
+            lines.append(f"  - {name}: {distance}メートル")
+        return "\n".join(lines)
+
+    elif tool_name == "tool_find_complementary_pois":
+        origin = output.get("origin_poi", "不明")
+        target = output.get("target_category", "不明")
+        count = output.get("count", 0)
+        lines = [f"{origin}の近くにある{target}（{count}件）:"]
+        for poi in output.get("complementary_pois", []):
+            name = poi.get("name", "不明")
+            distance = poi.get("distance_m", "不明")
+            lines.append(f"  - {name}: {distance}メートル")
+        return "\n".join(lines)
+
+    elif tool_name == "tool_find_pois_in_same_area":
+        origin = output.get("origin_poi", "不明")
+        area = output.get("area_cluster", "不明")
+        count = output.get("count", 0)
+        lines = [f"{origin}と同じエリア（{area}）のPOI（{count}件）:"]
+        for poi in output.get("same_area_pois", [])[:10]:
+            name = poi.get("name", "不明")
+            category = poi.get("category", "不明")
+            lines.append(f"  - {name}（{category}）")
+        return "\n".join(lines)
+
+    # フォールバック: 辞書のキーと値を日本語テキスト化
+    lines = []
+    for key, value in output.items():
+        if isinstance(value, list) and len(value) > 0:
+            lines.append(f"{key}: {len(value)}件")
+        else:
+            lines.append(f"{key}: {value}")
+    return "\n".join(lines) if lines else json.dumps(output, ensure_ascii=False)
 
 
 # =============================================================================
@@ -85,23 +330,25 @@ def get_global_pois() -> List[Dict[str, Any]]:
 @tool
 def tool_get_nearest_pois(
     category: Optional[str] = None,
-    top_n: int = 3
+    top_n: int = 3,
+    area: Optional[str] = None
 ) -> str:
     """
-    渋谷駅から最も近いPOIを検索します。
+    指定エリアの駅から最も近いPOIを検索します。
 
     Args:
         category: 検索するカテゴリ（例: "カフェ", "飲食店", "コンビニ"）。Noneの場合は全カテゴリ対象。
         top_n: 取得する件数（デフォルト: 3）
+        area: エリアキー（"shibuya", "shinjuku", "ikebukuro", "tokyo"）。Noneの場合は全エリア対象。
 
     Returns:
-        最寄りPOI情報のJSON文字列
+        最寄りPOI情報の日本語テキスト
 
     Examples:
-        - 最寄りのカフェを探す: tool_get_nearest_pois(category="カフェ", top_n=3)
-        - 最寄りのPOIを探す: tool_get_nearest_pois(top_n=5)
+        - 渋谷の最寄りカフェ: tool_get_nearest_pois(category="カフェ", top_n=3, area="shibuya")
+        - 新宿の最寄りPOI: tool_get_nearest_pois(top_n=5, area="shinjuku")
     """
-    pois = get_global_pois()
+    pois = get_global_pois(area)
     nearest = get_nearest_pois(pois, category, top_n)
 
     result = {
@@ -118,13 +365,14 @@ def tool_get_nearest_pois(
         ]
     }
 
-    return json.dumps(result, ensure_ascii=False, indent=2)
+    return format_tool_output_japanese("tool_get_nearest_pois", result)
 
 
 @tool
 def tool_count_pois_in_radius(
     radius_m: float,
-    category: Optional[str] = None
+    category: Optional[str] = None,
+    area: Optional[str] = None
 ) -> str:
     """
     指定した半径内のPOI件数を集計します。
@@ -132,15 +380,16 @@ def tool_count_pois_in_radius(
     Args:
         radius_m: 半径（メートル）
         category: フィルタするカテゴリ（部分一致）。Noneの場合は全カテゴリ対象。
+        area: エリアキー（"shibuya", "shinjuku", "ikebukuro", "tokyo"）。Noneの場合は全エリア対象。
 
     Returns:
-        集計結果のJSON文字列
+        集計結果の日本語テキスト
 
     Examples:
-        - 500m以内のカフェを数える: tool_count_pois_in_radius(radius_m=500, category="カフェ")
-        - 300m以内の全POIを数える: tool_count_pois_in_radius(radius_m=300)
+        - 渋谷の500m以内のカフェ: tool_count_pois_in_radius(radius_m=500, category="カフェ", area="shibuya")
+        - 新宿の300m以内の全POI: tool_count_pois_in_radius(radius_m=300, area="shinjuku")
     """
-    pois = get_global_pois()
+    pois = get_global_pois(area)
     count = count_by_radius(pois, radius_m, category)
 
     result = {
@@ -149,14 +398,15 @@ def tool_count_pois_in_radius(
         "count": count
     }
 
-    return json.dumps(result, ensure_ascii=False, indent=2)
+    return format_tool_output_japanese("tool_count_pois_in_radius", result)
 
 
 @tool
 def tool_compare_radius(
     radius1_m: float,
     radius2_m: float,
-    category: Optional[str] = None
+    category: Optional[str] = None,
+    area: Optional[str] = None
 ) -> str:
     """
     異なる半径での件数を比較します（感度分析）。
@@ -166,14 +416,15 @@ def tool_compare_radius(
         radius1_m: 半径1（メートル）
         radius2_m: 半径2（メートル）
         category: フィルタするカテゴリ。Noneの場合は全カテゴリ対象。
+        area: エリアキー（"shibuya", "shinjuku", "ikebukuro", "tokyo"）。Noneの場合は全エリア対象。
 
     Returns:
-        比較結果のJSON文字列
+        比較結果の日本語テキスト
 
     Examples:
-        - 300mと500mでカフェの件数を比較: tool_compare_radius(radius1_m=300, radius2_m=500, category="カフェ")
+        - 渋谷で300mと500mのカフェ比較: tool_compare_radius(radius1_m=300, radius2_m=500, category="カフェ", area="shibuya")
     """
-    pois = get_global_pois()
+    pois = get_global_pois(area)
     comparison = compare_by_radius(pois, radius1_m, radius2_m, category)
 
     result = {
@@ -187,13 +438,14 @@ def tool_compare_radius(
         "summary_jp": comparison.to_japanese()
     }
 
-    return json.dumps(result, ensure_ascii=False, indent=2)
+    return format_tool_output_japanese("tool_compare_radius", result)
 
 
 @tool
 def tool_analyze_sensitivity(
     category: Optional[str] = None,
-    radii: Optional[List[float]] = None
+    radii: Optional[List[float]] = None,
+    area: Optional[str] = None
 ) -> str:
     """
     複数の半径でのPOI件数変化を分析します（詳細な感度分析）。
@@ -201,23 +453,25 @@ def tool_analyze_sensitivity(
     Args:
         category: フィルタするカテゴリ
         radii: 分析する半径のリスト。Noneの場合は[100, 200, 300, 500, 800, 1000]
+        area: エリアキー（"shibuya", "shinjuku", "ikebukuro", "tokyo"）。Noneの場合は全エリア対象。
 
     Returns:
-        感度分析結果のJSON文字列
+        感度分析結果の日本語テキスト
 
     Examples:
-        - カフェの半径別件数を分析: tool_analyze_sensitivity(category="カフェ")
+        - 渋谷のカフェの半径別件数: tool_analyze_sensitivity(category="カフェ", area="shibuya")
     """
-    pois = get_global_pois()
+    pois = get_global_pois(area)
     result = analyze_radius_sensitivity(pois, category, radii)
 
-    return json.dumps(result, ensure_ascii=False, indent=2)
+    return format_tool_output_japanese("tool_analyze_sensitivity", result)
 
 
 @tool
 def tool_filter_by_area(
     radius_m: float,
-    category: Optional[str] = None
+    category: Optional[str] = None,
+    area: Optional[str] = None
 ) -> str:
     """
     指定した半径内のPOIリストを取得します。
@@ -225,14 +479,15 @@ def tool_filter_by_area(
     Args:
         radius_m: 半径（メートル）
         category: フィルタするカテゴリ
+        area: エリアキー（"shibuya", "shinjuku", "ikebukuro", "tokyo"）。Noneの場合は全エリア対象。
 
     Returns:
-        POIリストのJSON文字列
+        POIリストの日本語テキスト
 
     Examples:
-        - 500m以内のカフェをリスト化: tool_filter_by_area(radius_m=500, category="カフェ")
+        - 渋谷の500m以内のカフェ: tool_filter_by_area(radius_m=500, category="カフェ", area="shibuya")
     """
-    pois = get_global_pois()
+    pois = get_global_pois(area)
     filtered = filter_by_radius(pois, radius_m, category)
 
     result = {
@@ -246,11 +501,11 @@ def tool_filter_by_area(
                 "distance_m": poi.get("distance_from_station", "不明"),
                 "direction": poi.get("direction_from_station_jp", "不明")
             }
-            for poi in filtered[:20]  # 最大20件に制限
+            for poi in filtered[:20]
         ]
     }
 
-    return json.dumps(result, ensure_ascii=False, indent=2)
+    return format_tool_output_japanese("tool_filter_by_area", result)
 
 
 @tool
@@ -285,22 +540,28 @@ def tool_calculate_distance(
             break
 
     if not poi1:
-        return json.dumps({"error": f"POI '{poi_name1}' が見つかりません"}, ensure_ascii=False)
+        return format_tool_output_japanese("tool_calculate_distance", {"error": f"POI '{poi_name1}' が見つかりません"})
     if not poi2:
-        return json.dumps({"error": f"POI '{poi_name2}' が見つかりません"}, ensure_ascii=False)
+        return format_tool_output_japanese("tool_calculate_distance", {"error": f"POI '{poi_name2}' が見つかりません"})
 
-    distance = haversine_distance(
-        poi1["lat"], poi1["lon"],
-        poi2["lat"], poi2["lon"]
-    )
+    # メタデータ内のlat/lonにも対応
+    lat1 = poi1.get("lat") or poi1.get("metadata", {}).get("lat")
+    lon1 = poi1.get("lon") or poi1.get("metadata", {}).get("lon")
+    lat2 = poi2.get("lat") or poi2.get("metadata", {}).get("lat")
+    lon2 = poi2.get("lon") or poi2.get("metadata", {}).get("lon")
+
+    if not all([lat1, lon1, lat2, lon2]):
+        return format_tool_output_japanese("tool_calculate_distance", {"error": "座標情報が不足しています"})
+
+    distance = haversine_distance(lat1, lon1, lat2, lon2)
 
     result = {
-        "poi1": {"name": poi1["name"], "category": poi1.get("category", "不明")},
-        "poi2": {"name": poi2["name"], "category": poi2.get("category", "不明")},
+        "poi1": {"name": poi1.get("name", "不明"), "category": poi1.get("category", "不明")},
+        "poi2": {"name": poi2.get("name", "不明"), "category": poi2.get("category", "不明")},
         "distance_m": round(distance, 2)
     }
 
-    return json.dumps(result, ensure_ascii=False, indent=2)
+    return format_tool_output_japanese("tool_calculate_distance", result)
 
 
 # =============================================================================
@@ -309,22 +570,24 @@ def tool_calculate_distance(
 
 @tool
 def tool_compare_east_west(
-    category: Optional[str] = None
+    category: Optional[str] = None,
+    area: Optional[str] = None
 ) -> str:
     """
-    渋谷駅の東側と西側でPOI件数を比較します。
+    指定エリアの駅の東側と西側でPOI件数を比較します。
 
     Args:
         category: 比較するカテゴリ。Noneの場合は全カテゴリ対象。
+        area: エリアキー（"shibuya", "shinjuku", "ikebukuro", "tokyo"）。Noneの場合は全エリア対象。
 
     Returns:
-        東西比較結果のJSON文字列
+        東西比較結果の日本語テキスト
 
     Examples:
-        - カフェの東西比較: tool_compare_east_west(category="カフェ")
-        - 全POIの東西比較: tool_compare_east_west()
+        - 渋谷のカフェ東西比較: tool_compare_east_west(category="カフェ", area="shibuya")
+        - 新宿の全POI東西比較: tool_compare_east_west(area="shinjuku")
     """
-    pois = get_global_pois()
+    pois = get_global_pois(area)
     comparison = compare_east_west(pois, category)
 
     result = {
@@ -336,23 +599,25 @@ def tool_compare_east_west(
         "summary_jp": comparison.to_japanese()
     }
 
-    return json.dumps(result, ensure_ascii=False, indent=2)
+    return format_tool_output_japanese("tool_compare_east_west", result)
 
 
 @tool
 def tool_compare_north_south(
-    category: Optional[str] = None
+    category: Optional[str] = None,
+    area: Optional[str] = None
 ) -> str:
     """
-    渋谷駅の北側と南側でPOI件数を比較します。
+    指定エリアの駅の北側と南側でPOI件数を比較します。
 
     Args:
         category: 比較するカテゴリ。Noneの場合は全カテゴリ対象。
+        area: エリアキー（"shibuya", "shinjuku", "ikebukuro", "tokyo"）。Noneの場合は全エリア対象。
 
     Returns:
-        南北比較結果のJSON文字列
+        南北比較結果の日本語テキスト
     """
-    pois = get_global_pois()
+    pois = get_global_pois(area)
     comparison = compare_north_south(pois, category)
 
     result = {
@@ -364,59 +629,61 @@ def tool_compare_north_south(
         "summary_jp": comparison.to_japanese()
     }
 
-    return json.dumps(result, ensure_ascii=False, indent=2)
+    return format_tool_output_japanese("tool_compare_north_south", result)
 
 
 @tool
 def tool_count_by_category(
-    categories: Optional[List[str]] = None
+    categories: Optional[List[str]] = None,
+    area: Optional[str] = None
 ) -> str:
     """
     カテゴリ別にPOI件数を集計します。
 
     Args:
         categories: 集計するカテゴリのリスト。Noneの場合は全カテゴリを集計。
+        area: エリアキー（"shibuya", "shinjuku", "ikebukuro", "tokyo"）。Noneの場合は全エリア対象。
 
     Returns:
-        カテゴリ別集計結果のJSON文字列
+        カテゴリ別集計結果の日本語テキスト
 
     Examples:
-        - 全カテゴリを集計: tool_count_by_category()
-        - 特定カテゴリのみ集計: tool_count_by_category(categories=["カフェ", "レストラン"])
+        - 渋谷の全カテゴリ集計: tool_count_by_category(area="shibuya")
+        - 新宿の特定カテゴリ集計: tool_count_by_category(categories=["カフェ", "レストラン"], area="shinjuku")
     """
-    pois = get_global_pois()
+    pois = get_global_pois(area)
 
     if categories:
-        # 特定カテゴリのみ
         result = {}
         for cat in categories:
             filtered = filter_by_category(pois, cat)
             result[cat] = len(filtered)
     else:
-        # 全カテゴリ
         result = count_by_category(pois)
 
-    return json.dumps(result, ensure_ascii=False, indent=2)
+    return format_tool_output_japanese("tool_count_by_category", result)
 
 
 @tool
 def tool_get_top_categories(
-    top_n: int = 5
+    top_n: int = 5,
+    area: Optional[str] = None
 ) -> str:
     """
     件数上位のカテゴリランキングを取得します。
 
     Args:
         top_n: 取得する件数（デフォルト: 5）
+        area: エリアキー（"shibuya", "shinjuku", "ikebukuro", "tokyo"）。Noneの場合は全エリア対象。
 
     Returns:
-        ランキング結果のJSON文字列
+        ランキング結果の日本語テキスト
 
     Examples:
-        - トップ5カテゴリ: tool_get_top_categories(top_n=5)
-        - トップ10カテゴリ: tool_get_top_categories(top_n=10)
+        - 渋谷のトップ5カテゴリ: tool_get_top_categories(top_n=5, area="shibuya")
+        - 全エリアのトップ10: tool_get_top_categories(top_n=10)
     """
-    pois = get_global_pois()
+    pois = get_global_pois(area)
     top_cats = get_top_categories(pois, top_n, include_examples=True, example_count=3)
 
     result = {
@@ -432,29 +699,31 @@ def tool_get_top_categories(
         ]
     }
 
-    return json.dumps(result, ensure_ascii=False, indent=2)
+    return format_tool_output_japanese("tool_get_top_categories", result)
 
 
 @tool
 def tool_analyze_category_by_direction(
-    category: str
+    category: str,
+    area: Optional[str] = None
 ) -> str:
     """
     特定カテゴリのPOIを方向別に詳細分析します。
 
     Args:
         category: 分析するカテゴリ
+        area: エリアキー（"shibuya", "shinjuku", "ikebukuro", "tokyo"）。Noneの場合は全エリア対象。
 
     Returns:
-        方向別分析結果のJSON文字列
+        方向別分析結果の日本語テキスト
 
     Examples:
-        - カフェの方向別分析: tool_analyze_category_by_direction(category="カフェ")
+        - 渋谷のカフェ方向別分析: tool_analyze_category_by_direction(category="カフェ", area="shibuya")
     """
-    pois = get_global_pois()
+    pois = get_global_pois(area)
     analysis = analyze_category_by_direction(pois, category)
 
-    return json.dumps(analysis, ensure_ascii=False, indent=2)
+    return format_tool_output_japanese("tool_analyze_category_by_direction", analysis)
 
 
 # =============================================================================
@@ -507,7 +776,7 @@ def tool_vector_search(
         ]
     }
 
-    return json.dumps(result, ensure_ascii=False, indent=2)
+    return format_tool_output_japanese("tool_vector_search", result)
 
 
 @tool
@@ -521,7 +790,7 @@ def tool_find_pois_by_keyword(
         keyword: 検索キーワード
 
     Returns:
-        検索結果のJSON文字列
+        検索結果の日本語テキスト
 
     Examples:
         - "スターバックス"を検索: tool_find_pois_by_keyword(keyword="スターバックス")
@@ -546,11 +815,11 @@ def tool_find_pois_by_keyword(
                 "distance_m": poi.get("distance_from_station", "不明"),
                 "direction": poi.get("direction_from_station_jp", "不明")
             }
-            for poi in results[:20]  # 最大20件
+            for poi in results[:20]
         ]
     }
 
-    return json.dumps(result, ensure_ascii=False, indent=2)
+    return format_tool_output_japanese("tool_find_pois_by_keyword", result)
 
 
 # =============================================================================
@@ -585,23 +854,27 @@ def tool_find_nearby_similar_pois(
             break
 
     if not origin_poi:
-        return json.dumps({"error": f"POI '{poi_name}' が見つかりません"}, ensure_ascii=False)
+        return format_tool_output_japanese("tool_find_nearby_similar_pois", {"error": f"POI '{poi_name}' が見つかりません"})
 
     # 同カテゴリで近隣のPOIを検索
     origin_category = origin_poi.get("category", "")
-    origin_lat = origin_poi["lat"]
-    origin_lon = origin_poi["lon"]
+    origin_lat = origin_poi.get("lat") or origin_poi.get("metadata", {}).get("lat")
+    origin_lon = origin_poi.get("lon") or origin_poi.get("metadata", {}).get("lon")
+
+    if not origin_lat or not origin_lon:
+        return format_tool_output_japanese("tool_find_nearby_similar_pois", {"error": "起点POIの座標情報がありません"})
 
     nearby_pois = []
     for poi in pois:
         if poi.get("name") == origin_poi.get("name"):
-            continue  # 自分自身は除外
+            continue
 
         if origin_category in poi.get("category", ""):
-            distance = haversine_distance(
-                origin_lat, origin_lon,
-                poi["lat"], poi["lon"]
-            )
+            poi_lat = poi.get("lat") or poi.get("metadata", {}).get("lat")
+            poi_lon = poi.get("lon") or poi.get("metadata", {}).get("lon")
+            if not poi_lat or not poi_lon:
+                continue
+            distance = haversine_distance(origin_lat, origin_lon, poi_lat, poi_lon)
             if distance <= max_distance_m:
                 nearby_pois.append({
                     "name": poi.get("name", "不明"),
@@ -610,7 +883,6 @@ def tool_find_nearby_similar_pois(
                     "direction": poi.get("direction_from_station_jp", "不明")
                 })
 
-    # 距離でソート
     nearby_pois.sort(key=lambda x: x["distance_m"])
 
     result = {
@@ -618,10 +890,10 @@ def tool_find_nearby_similar_pois(
         "origin_category": origin_category,
         "max_distance_m": max_distance_m,
         "count": len(nearby_pois),
-        "nearby_pois": nearby_pois[:10]  # 最大10件
+        "nearby_pois": nearby_pois[:10]
     }
 
-    return json.dumps(result, ensure_ascii=False, indent=2)
+    return format_tool_output_japanese("tool_find_nearby_similar_pois", result)
 
 
 @tool
@@ -656,19 +928,23 @@ def tool_find_complementary_pois(
             break
 
     if not origin_poi:
-        return json.dumps({"error": f"POI '{poi_name}' が見つかりません"}, ensure_ascii=False)
+        return format_tool_output_japanese("tool_find_complementary_pois", {"error": f"POI '{poi_name}' が見つかりません"})
 
     # 指定カテゴリで近隣のPOIを検索
-    origin_lat = origin_poi["lat"]
-    origin_lon = origin_poi["lon"]
+    origin_lat = origin_poi.get("lat") or origin_poi.get("metadata", {}).get("lat")
+    origin_lon = origin_poi.get("lon") or origin_poi.get("metadata", {}).get("lon")
+
+    if not origin_lat or not origin_lon:
+        return format_tool_output_japanese("tool_find_complementary_pois", {"error": "起点POIの座標情報がありません"})
 
     nearby_pois = []
     for poi in pois:
         if target_category.lower() in poi.get("category", "").lower():
-            distance = haversine_distance(
-                origin_lat, origin_lon,
-                poi["lat"], poi["lon"]
-            )
+            poi_lat = poi.get("lat") or poi.get("metadata", {}).get("lat")
+            poi_lon = poi.get("lon") or poi.get("metadata", {}).get("lon")
+            if not poi_lat or not poi_lon:
+                continue
+            distance = haversine_distance(origin_lat, origin_lon, poi_lat, poi_lon)
             if distance <= max_distance_m:
                 nearby_pois.append({
                     "name": poi.get("name", "不明"),
@@ -677,7 +953,6 @@ def tool_find_complementary_pois(
                     "direction": poi.get("direction_from_station_jp", "不明")
                 })
 
-    # 距離でソート
     nearby_pois.sort(key=lambda x: x["distance_m"])
 
     result = {
@@ -686,10 +961,10 @@ def tool_find_complementary_pois(
         "target_category": target_category,
         "max_distance_m": max_distance_m,
         "count": len(nearby_pois),
-        "complementary_pois": nearby_pois[:10]  # 最大10件
+        "complementary_pois": nearby_pois[:10]
     }
 
-    return json.dumps(result, ensure_ascii=False, indent=2)
+    return format_tool_output_japanese("tool_find_complementary_pois", result)
 
 
 @tool
@@ -720,20 +995,19 @@ def tool_find_pois_in_same_area(
             break
 
     if not origin_poi:
-        return json.dumps({"error": f"POI '{poi_name}' が見つかりません"}, ensure_ascii=False)
+        return format_tool_output_japanese("tool_find_pois_in_same_area", {"error": f"POI '{poi_name}' が見つかりません"})
 
     # 同じエリアクラスタのPOIを検索
     origin_area = origin_poi.get("area_cluster", "")
     if not origin_area:
-        return json.dumps({"error": "起点POIのエリア情報がありません"}, ensure_ascii=False)
+        return format_tool_output_japanese("tool_find_pois_in_same_area", {"error": "起点POIのエリア情報がありません"})
 
     same_area_pois = []
     for poi in pois:
         if poi.get("name") == origin_poi.get("name"):
-            continue  # 自分自身は除外
+            continue
 
         if poi.get("area_cluster") == origin_area:
-            # カテゴリフィルタ
             if target_category and target_category.lower() not in poi.get("category", "").lower():
                 continue
 
@@ -749,10 +1023,10 @@ def tool_find_pois_in_same_area(
         "area_cluster": origin_area,
         "target_category": target_category or "全て",
         "count": len(same_area_pois),
-        "same_area_pois": same_area_pois[:20]  # 最大20件
+        "same_area_pois": same_area_pois[:20]
     }
 
-    return json.dumps(result, ensure_ascii=False, indent=2)
+    return format_tool_output_japanese("tool_find_pois_in_same_area", result)
 
 
 # =============================================================================
@@ -792,7 +1066,7 @@ def get_all_tools() -> List:
 def test_tools():
     """ツール動作確認"""
     print("=" * 60)
-    print("agent_tools.py 動作確認")
+    print("agent_tools.py 動作確認（Phase 9-B 広域対応 + 中国語混入対策）")
     print("=" * 60)
 
     # テスト用POIデータ読み込み
@@ -819,17 +1093,50 @@ def test_tools():
 
     print(f"\nPOIデータ読み込み完了: {len(pois)}件")
 
-    # ツールテスト
-    print("\n--- 最寄りカフェ検索 ---")
-    print(tool_get_nearest_pois.invoke({"category": "カフェ", "top_n": 3}))
+    # ツールテスト（日本語自然文出力の確認）
+    print("\n--- 最寄りカフェ検索（日本語出力） ---")
+    output = tool_get_nearest_pois.invoke({"category": "カフェ", "top_n": 3})
+    print(output)
+    # JSON形式でないことを確認
+    assert not output.strip().startswith("{"), "ツール出力がJSON形式です（日本語自然文であるべき）"
 
-    print("\n--- 500m以内のカフェ件数 ---")
-    print(tool_count_pois_in_radius.invoke({"radius_m": 500, "category": "カフェ"}))
+    print("\n--- 500m以内のカフェ件数（日本語出力） ---")
+    output = tool_count_pois_in_radius.invoke({"radius_m": 500, "category": "カフェ"})
+    print(output)
+    assert not output.strip().startswith("{"), "ツール出力がJSON形式です"
 
-    print("\n--- 東西比較（カフェ） ---")
-    print(tool_compare_east_west.invoke({"category": "カフェ"}))
+    print("\n--- 東西比較カフェ（日本語出力） ---")
+    output = tool_compare_east_west.invoke({"category": "カフェ"})
+    print(output)
+    assert not output.strip().startswith("{"), "ツール出力がJSON形式です"
 
-    print("\n✅ agent_tools.py 動作確認完了")
+    # format_tool_output_japanese のテスト
+    print("\n--- format_tool_output_japanese テスト ---")
+    test_output = {
+        "category": "カフェ",
+        "count": 2,
+        "pois": [
+            {"name": "スターバックス渋谷店", "direction": "東", "distance_m": 150.5},
+            {"name": "タリーズ宮益坂店", "direction": "北東", "distance_m": 200.3},
+        ]
+    }
+    formatted = format_tool_output_japanese("tool_get_nearest_pois", test_output)
+    assert "スターバックス渋谷店" in formatted
+    assert "150.5メートル" in formatted
+    assert "{" not in formatted  # JSON形式でないこと
+    print(formatted)
+
+    # set_global_pois_multi_area のテスト
+    print("\n--- set_global_pois_multi_area テスト ---")
+    test_areas_config = {
+        "shibuya": {"name": "渋谷駅周辺", "station": {"name": "渋谷駅", "lat": 35.658034, "lon": 139.701636}},
+    }
+    set_global_pois_multi_area(pois, test_areas_config)
+    area_pois = get_global_pois("shibuya")
+    print(f"  全POI: {len(get_global_pois())}件")
+    print(f"  渋谷POI: {len(area_pois)}件")
+
+    print("\n✅ agent_tools.py 動作確認完了（広域対応 + 中国語混入対策）")
 
 
 if __name__ == "__main__":

--- a/src/agentic_rag_system.py
+++ b/src/agentic_rag_system.py
@@ -36,7 +36,8 @@ try:
     )
     from .agent_tools import (
         get_all_tools,
-        set_global_pois
+        set_global_pois,
+        set_global_pois_multi_area
     )
     from .agent_prompts import (
         AGENT_SYSTEM_PROMPT,
@@ -44,7 +45,7 @@ try:
         format_answer_generation_prompt,
         generate_tools_description
     )
-    from .geo_utils import enrich_all_pois
+    from .geo_utils import enrich_all_pois, enrich_all_areas
 except ImportError:
     from agent_state import (
         AgentState,
@@ -59,7 +60,8 @@ except ImportError:
     )
     from agent_tools import (
         get_all_tools,
-        set_global_pois
+        set_global_pois,
+        set_global_pois_multi_area
     )
     from agent_prompts import (
         AGENT_SYSTEM_PROMPT,
@@ -67,7 +69,7 @@ except ImportError:
         format_answer_generation_prompt,
         generate_tools_description
     )
-    from geo_utils import enrich_all_pois
+    from geo_utils import enrich_all_pois, enrich_all_areas
 
 
 # =============================================================================
@@ -231,6 +233,8 @@ class AgenticRAGSystem:
         """
         モデルの出力からツール呼び出しをパース
 
+        日本語メタ言語（行動/行動入力）と英語メタ言語（Action/Action Input）の両方に対応。
+
         Args:
             response: モデルの出力テキスト
 
@@ -239,23 +243,31 @@ class AgenticRAGSystem:
         """
         tool_calls = []
 
-        # パターン: Action: tool_name
-        # Action Input: {"arg1": "value1", ...}
-        pattern = r'Action:\s*(\w+)\s*\n\s*Action Input:\s*(\{[^}]+\})'
-        matches = re.finditer(pattern, response, re.MULTILINE)
+        # 日本語メタ言語パターン（Phase 9-B）
+        # 行動: tool_name
+        # 行動入力: {"arg1": "value1", ...}
+        patterns = [
+            r'行動:\s*(\w+)\s*\n\s*行動入力:\s*(\{[^}]+\})',
+            r'Action:\s*(\w+)\s*\n\s*Action Input:\s*(\{[^}]+\})',
+        ]
 
-        for match in matches:
-            tool_name = match.group(1)
-            try:
-                args_str = match.group(2)
-                args = json.loads(args_str)
-                tool_calls.append({
-                    "tool": tool_name,
-                    "args": args
-                })
-            except json.JSONDecodeError:
-                if self.verbose:
-                    print(f"Failed to parse tool arguments: {match.group(2)}")
+        for pattern in patterns:
+            matches = re.finditer(pattern, response, re.MULTILINE)
+            for match in matches:
+                tool_name = match.group(1)
+                try:
+                    args_str = match.group(2)
+                    args = json.loads(args_str)
+                    tool_calls.append({
+                        "tool": tool_name,
+                        "args": args
+                    })
+                except json.JSONDecodeError:
+                    if self.verbose:
+                        print(f"Failed to parse tool arguments: {match.group(2)}")
+
+            if tool_calls:
+                break  # 最初にマッチしたパターンの結果を使用
 
         return tool_calls
 
@@ -275,30 +287,30 @@ class AgenticRAGSystem:
         # イテレーションをインクリメント
         state = increment_iteration(state)
 
-        # プロンプト構築
+        # プロンプト構築（日本語ReActフォーマット）
         prompt_parts = [
-            f"Question: {state['question']}\n"
+            f"質問: {state['question']}\n"
         ]
 
         # ツール説明
         tools_desc = generate_tools_description()
-        prompt_parts.append(f"\nAvailable Tools:\n{tools_desc}\n")
+        prompt_parts.append(f"\n利用可能なツール:\n{tools_desc}\n")
 
         # これまでのツール実行結果を追加
         if state["tool_results"]:
-            prompt_parts.append("\nPrevious Tool Executions:")
+            prompt_parts.append("\nこれまでのツール実行結果:")
             for r in state["tool_results"]:
-                prompt_parts.append(f"\nTool: {r['tool']}")
-                prompt_parts.append(f"Output: {r['output']}")
+                prompt_parts.append(f"\nツール: {r['tool']}")
+                prompt_parts.append(f"結果: {r['output']}")
 
-        # ReAct指示
-        prompt_parts.append("\n\nUse the ReAct format:")
-        prompt_parts.append("Thought: [your reasoning]")
-        prompt_parts.append("Action: [tool_name]")
-        prompt_parts.append("Action Input: {\"arg1\": \"value1\", ...}")
-        prompt_parts.append("\nOr, if you have enough information:")
-        prompt_parts.append("Thought: I now have enough information to answer")
-        prompt_parts.append("Final Answer: [your answer]")
+        # ReAct指示（日本語メタ言語）
+        prompt_parts.append("\n\n以下のフォーマットで回答してください:")
+        prompt_parts.append("思考: [考えの内容]")
+        prompt_parts.append("行動: [ツール名]")
+        prompt_parts.append("行動入力: {\"arg1\": \"value1\", ...}")
+        prompt_parts.append("\nまたは、十分な情報がある場合:")
+        prompt_parts.append("思考: 十分な情報が集まったので最終回答を生成できる")
+        prompt_parts.append("最終回答: [回答内容（必ず日本語で）]")
 
         prompt = "\n".join(prompt_parts)
 
@@ -322,8 +334,11 @@ class AgenticRAGSystem:
                 if self.verbose:
                     print(f"Parsed tool calls: {[tc['tool'] for tc in tool_calls]}")
             else:
-                # ツール呼び出しがない場合は最終回答を抽出
-                final_answer_match = re.search(r'Final Answer:\s*(.+?)(?:\n|$)', response, re.DOTALL)
+                # ツール呼び出しがない場合は最終回答を抽出（日本語/英語両対応）
+                final_answer_match = (
+                    re.search(r'最終回答:\s*(.+?)(?:\n|$)', response, re.DOTALL)
+                    or re.search(r'Final Answer:\s*(.+?)(?:\n|$)', response, re.DOTALL)
+                )
                 if final_answer_match:
                     answer = final_answer_match.group(1).strip()
                     state = set_final_answer(state, answer)
@@ -551,12 +566,16 @@ class AgenticRAGSystem:
 # ヘルパー関数
 # =============================================================================
 
-def load_poi_data(poi_file: str = "poi_documents.json") -> List[Dict[str, Any]]:
+def load_poi_data(
+    poi_file: str = "poi_documents.json",
+    areas_config: Optional[Dict[str, Any]] = None
+) -> List[Dict[str, Any]]:
     """
     POIデータを読み込み、空間情報を付加
 
     Args:
         poi_file: POIデータファイルのパス
+        areas_config: エリア設定辞書（None時は渋谷単一エリア）
 
     Returns:
         空間情報付きPOIリスト
@@ -570,20 +589,20 @@ def load_poi_data(poi_file: str = "poi_documents.json") -> List[Dict[str, Any]]:
     flat_pois = []
     for poi in raw_pois:
         if "metadata" in poi:
-            # metadata形式の場合はフラット化
             flat_poi = poi["metadata"].copy()
             flat_pois.append(flat_poi)
         else:
-            # 既にフラット化されている場合はそのまま
             flat_pois.append(poi)
 
-    # 空間情報付加
-    pois = enrich_all_pois(flat_pois)
-
-    # グローバルPOI設定
-    set_global_pois(pois)
-
-    print(f"✓ Loaded {len(pois)} POIs with spatial info")
+    # 空間情報付加（広域対応）
+    if areas_config and len(areas_config) > 1:
+        pois = enrich_all_areas(flat_pois, areas_config)
+        set_global_pois_multi_area(pois, areas_config)
+        print(f"✓ Loaded {len(pois)} POIs with spatial info ({len(areas_config)} areas)")
+    else:
+        pois = enrich_all_pois(flat_pois)
+        set_global_pois(pois)
+        print(f"✓ Loaded {len(pois)} POIs with spatial info")
 
     return pois
 
@@ -593,6 +612,7 @@ def initialize_system(
     model = None,
     tokenizer = None,
     model_name: str = "Qwen/Qwen2.5-7B-Instruct",
+    areas_config: Optional[Dict[str, Any]] = None,
     verbose: bool = True,
     load_in_4bit: bool = True
 ) -> AgenticRAGSystem:
@@ -604,14 +624,15 @@ def initialize_system(
         model: 事前ロード済みのHuggingFaceモデル（Noneの場合は自動ロード）
         tokenizer: 事前ロード済みのトークナイザー（Noneの場合は自動ロード）
         model_name: LLMモデル名
+        areas_config: エリア設定辞書（None時は渋谷単一エリア）
         verbose: デバッグ出力
         load_in_4bit: 4bit量子化を使用するか
 
     Returns:
         初期化されたAgenticRAGSystem
     """
-    # POIデータ読み込み
-    load_poi_data(poi_file)
+    # POIデータ読み込み（広域対応）
+    load_poi_data(poi_file, areas_config=areas_config)
 
     # システム初期化
     system = AgenticRAGSystem(

--- a/src/graph_rag_system.py
+++ b/src/graph_rag_system.py
@@ -33,6 +33,7 @@ try:
         SHIBUYA_STATION,
         DIRECTION_JP
     )
+    from .geo_utils import detect_target_area
 except ImportError:
     from graph_builder import (
         POIGraphBuilder,
@@ -44,6 +45,7 @@ except ImportError:
         SHIBUYA_STATION,
         DIRECTION_JP
     )
+    from geo_utils import detect_target_area
 
 
 # =============================================================================
@@ -270,31 +272,59 @@ def analyze_graph_query(question: str) -> GraphQueryAnalysis:
 class GraphRAGSystem:
     """ナレッジグラフを活用したRAGシステム"""
 
-    def __init__(self, graph_or_pois=None, poi_json_path: str = None):
+    def __init__(self, graph_or_pois=None, poi_json_path: str = None,
+                 areas_config: Optional[Dict[str, Any]] = None,
+                 all_pois: Optional[List[Dict[str, Any]]] = None):
         """
         Args:
             graph_or_pois: 構築済みのNetworkXグラフ、またはPOIリスト（List[Dict]）
             poi_json_path: POI JSONファイルのパス（グラフ未構築時）
+            areas_config: エリア設定辞書。指定時はエリア別グラフを構築。
+            all_pois: 全POIリスト（areas_config使用時に必要）
         """
         if not HAS_NETWORKX:
             raise ImportError("networkx is required")
 
-        if graph_or_pois is not None:
+        self.areas_config = areas_config or {
+            "shibuya": {"name": "渋谷駅周辺", "station": SHIBUYA_STATION}
+        }
+        self.graphs: Dict[str, nx.DiGraph] = {}
+        self.indices_by_area: Dict[str, Dict] = {}
+
+        # エリア別グラフ構築
+        if areas_config and len(areas_config) > 1 and all_pois is not None:
+            for area_key, area_info in areas_config.items():
+                area_pois = [
+                    p for p in all_pois
+                    if (p.get("area_key") or p.get("metadata", {}).get("area_key")) == area_key
+                ]
+                station = area_info.get("station", SHIBUYA_STATION)
+                builder = POIGraphBuilder(station=station)
+                self.graphs[area_key] = builder.build_graph(area_pois, verbose=False)
+            # デフォルトグラフは最初のエリア
+            first_key = next(iter(self.graphs))
+            self.graph = self.graphs[first_key]
+        elif graph_or_pois is not None:
             if isinstance(graph_or_pois, nx.DiGraph):
-                # NetworkXグラフが渡された場合
                 self.graph = graph_or_pois
             elif isinstance(graph_or_pois, list):
-                # POIリストが渡された場合
                 self.graph = self._build_graph_from_pois(graph_or_pois)
             else:
                 raise ValueError(f"Expected nx.DiGraph or list, got {type(graph_or_pois)}")
+            self.graphs["shibuya"] = self.graph
         elif poi_json_path is not None:
             self.graph = self._build_graph(poi_json_path)
+            self.graphs["shibuya"] = self.graph
         else:
-            raise ValueError("Either graph_or_pois or poi_json_path must be provided")
+            raise ValueError("Either graph_or_pois, poi_json_path, or (areas_config + all_pois) must be provided")
 
         # ノードインデックスの構築
         self._build_indices()
+
+        # エリア別インデックスも構築
+        if len(self.graphs) > 1:
+            for area_key, graph in self.graphs.items():
+                self.indices_by_area[area_key] = self._build_indices_for_graph(graph)
 
     def _build_graph(self, poi_json_path: str) -> nx.DiGraph:
         """POI JSONファイルパスからグラフを構築"""
@@ -307,8 +337,40 @@ class GraphRAGSystem:
         builder = POIGraphBuilder()
         return builder.build_graph(pois, verbose=False)
 
+    def _build_indices_for_graph(self, graph: nx.DiGraph) -> Dict:
+        """特定グラフ用のインデックスを構築"""
+        indices = {
+            "poi_nodes": {},
+            "category_nodes": {},
+            "area_nodes": {},
+            "subcategory_to_pois": defaultdict(list),
+            "category_to_pois": defaultdict(list),
+            "area_to_pois": defaultdict(list),
+        }
+
+        for node, data in graph.nodes(data=True):
+            node_type = data.get("node_type", "")
+
+            if node_type == "poi":
+                indices["poi_nodes"][node] = data
+                subcategory = data.get("subcategory", "")
+                if subcategory:
+                    indices["subcategory_to_pois"][subcategory].append(node)
+                category = data.get("category", "")
+                if category:
+                    indices["category_to_pois"][category].append(node)
+                area = data.get("area_cluster", "")
+                if area:
+                    indices["area_to_pois"][area].append(node)
+            elif node_type == "category":
+                indices["category_nodes"][node] = data
+            elif node_type == "area":
+                indices["area_nodes"][node] = data
+
+        return indices
+
     def _build_indices(self):
-        """高速検索用のインデックスを構築"""
+        """高速検索用のインデックスを構築（デフォルトグラフ用）"""
         self.poi_nodes = {}
         self.category_nodes = {}
         self.area_nodes = {}
@@ -322,17 +384,14 @@ class GraphRAGSystem:
             if node_type == "poi":
                 self.poi_nodes[node] = data
 
-                # サブカテゴリインデックス
                 subcategory = data.get("subcategory", "")
                 if subcategory:
                     self.subcategory_to_pois[subcategory].append(node)
 
-                # カテゴリインデックス
                 category = data.get("category", "")
                 if category:
                     self.category_to_pois[category].append(node)
 
-                # エリアインデックス
                 area = data.get("area_cluster", "")
                 if area:
                     self.area_to_pois[area].append(node)
@@ -342,6 +401,27 @@ class GraphRAGSystem:
 
             elif node_type == "area":
                 self.area_nodes[node] = data
+
+    def _select_graph_and_indices(self, question: str) -> Tuple:
+        """質問文からエリアを特定し、適切なグラフとインデックスを選択"""
+        if len(self.graphs) <= 1:
+            return (self.graph, self.poi_nodes, self.category_nodes,
+                    self.area_nodes, self.subcategory_to_pois,
+                    self.category_to_pois, self.area_to_pois)
+
+        target_area = detect_target_area(question, self.areas_config)
+
+        if target_area and target_area in self.indices_by_area:
+            idx = self.indices_by_area[target_area]
+            return (self.graphs[target_area],
+                    idx["poi_nodes"], idx["category_nodes"],
+                    idx["area_nodes"], idx["subcategory_to_pois"],
+                    idx["category_to_pois"], idx["area_to_pois"])
+
+        # エリア不明の場合はデフォルトグラフ（全インデックスを統合）
+        return (self.graph, self.poi_nodes, self.category_nodes,
+                self.area_nodes, self.subcategory_to_pois,
+                self.category_to_pois, self.area_to_pois)
 
     def query(self, question: str, top_k: int = 10) -> GraphQueryResult:
         """
@@ -354,6 +434,22 @@ class GraphRAGSystem:
         Returns:
             GraphQueryResult
         """
+        # Phase 9-B: エリア別グラフ選択
+        if len(self.graphs) > 1:
+            (selected_graph, poi_nodes, category_nodes, area_nodes,
+             subcategory_to_pois, category_to_pois, area_to_pois) = \
+                self._select_graph_and_indices(question)
+
+            # 一時的にインスタンス変数を差し替え
+            orig = (self.graph, self.poi_nodes, self.category_nodes,
+                    self.area_nodes, self.subcategory_to_pois,
+                    self.category_to_pois, self.area_to_pois)
+            (self.graph, self.poi_nodes, self.category_nodes,
+             self.area_nodes, self.subcategory_to_pois,
+             self.category_to_pois, self.area_to_pois) = \
+                (selected_graph, poi_nodes, category_nodes, area_nodes,
+                 subcategory_to_pois, category_to_pois, area_to_pois)
+
         # 質問分析
         analysis = analyze_graph_query(question)
 
@@ -378,6 +474,12 @@ class GraphRAGSystem:
         # コンテキスト生成
         result.context = self._generate_context(result, analysis)
         result.metadata["analysis"] = analysis.to_dict()
+
+        # インスタンス変数を復元
+        if len(self.graphs) > 1:
+            (self.graph, self.poi_nodes, self.category_nodes,
+             self.area_nodes, self.subcategory_to_pois,
+             self.category_to_pois, self.area_to_pois) = orig
 
         return result
 
@@ -672,7 +774,7 @@ class GraphRAGSystem:
                 direction = DIRECTION_JP.get(node.get("direction", ""), "不明")
                 subcategory = node.get("subcategory", "")
                 context_parts.append(
-                    f"{i}. {name} ({subcategory}) - 渋谷駅から{direction}へ{distance:.0f}m"
+                    f"{i}. {name} ({subcategory}) - 駅から{direction}へ{distance:.0f}m"
                 )
 
         elif analysis.question_type == "relation":
@@ -766,14 +868,23 @@ class GraphRAGSystem:
 
     def get_graph_stats(self) -> Dict[str, Any]:
         """グラフ統計情報を取得"""
-        return {
+        stats = {
             "num_poi_nodes": len(self.poi_nodes),
             "num_category_nodes": len(self.category_nodes),
             "num_area_nodes": len(self.area_nodes),
             "num_edges": self.graph.number_of_edges(),
             "categories": list(self.category_to_pois.keys()),
-            "subcategories": list(self.subcategory_to_pois.keys())
+            "subcategories": list(self.subcategory_to_pois.keys()),
+            "num_area_graphs": len(self.graphs),
         }
+        if len(self.graphs) > 1:
+            stats["area_graph_stats"] = {}
+            for area_key, graph in self.graphs.items():
+                stats["area_graph_stats"][area_key] = {
+                    "nodes": graph.number_of_nodes(),
+                    "edges": graph.number_of_edges(),
+                }
+        return stats
 
 
 # =============================================================================

--- a/src/structured_rag_system.py
+++ b/src/structured_rag_system.py
@@ -16,12 +16,14 @@ import torch
 try:
     from .geo_utils import (
         enrich_all_pois,
+        enrich_all_areas,
         filter_by_distance,
         filter_east_side,
         filter_west_side,
         distance_from_station,
         direction_from_station,
         SHIBUYA_STATION,
+        detect_target_area,
         # Phase 6.2追加
         get_nearest_pois,
         get_farthest_pois,
@@ -48,12 +50,14 @@ try:
 except ImportError:
     from geo_utils import (
         enrich_all_pois,
+        enrich_all_areas,
         filter_by_distance,
         filter_east_side,
         filter_west_side,
         distance_from_station,
         direction_from_station,
         SHIBUYA_STATION,
+        detect_target_area,
         get_nearest_pois,
         get_farthest_pois,
         filter_by_radius,
@@ -284,33 +288,61 @@ class StructuredRAGSystem:
         tokenizer,
         vectorstore,
         all_pois: List[Dict[str, Any]],
+        areas_config: Optional[Dict[str, Any]] = None,
         debug: bool = False
     ):
         """
         RAGシステムを初期化
-        
+
         Args:
             model: Hugging Face Transformersモデル
             tokenizer: トークナイザー
             vectorstore: LangChain ChromaDBベクトルストア
             all_pois: 全POIデータ（集計用）
+            areas_config: エリア設定辞書。None時は渋谷単一エリア（後方互換）
             debug: デバッグ出力を有効にする
         """
         self.model = model
         self.tokenizer = tokenizer
         self.vectorstore = vectorstore
         self.debug = debug
-        
-        # 全POIデータに空間情報を追加
-        self.all_pois = enrich_all_pois(all_pois)
-        
+        self.areas_config = areas_config or {
+            "shibuya": {"name": "渋谷駅周辺", "station": SHIBUYA_STATION}
+        }
+
+        # エリア別にPOIを空間情報付与
+        if areas_config and len(areas_config) > 1:
+            self.all_pois = enrich_all_areas(all_pois, areas_config)
+        else:
+            self.all_pois = enrich_all_pois(all_pois)
+
+        # エリア別POIインデックス
+        self.pois_by_area: Dict[str, List[Dict[str, Any]]] = {}
+        for poi in self.all_pois:
+            area_key = (poi.get("area_key")
+                        or poi.get("metadata", {}).get("area_key", "shibuya"))
+            self.pois_by_area.setdefault(area_key, []).append(poi)
+
         if self.debug:
             print(f"✅ StructuredRAGSystem初期化完了")
             print(f"   POI数: {len(self.all_pois)}件")
+            print(f"   エリア数: {len(self.pois_by_area)}")
+            for area_key, area_pois in self.pois_by_area.items():
+                print(f"     {area_key}: {len(area_pois)}件")
             print(f"   空間情報付与: 完了")
-        
-        # システムプロンプト
-        self.system_prompt = """あなたは渋谷エリアの地理情報に詳しいアシスタントです。
+
+        # システムプロンプト（広域対応）
+        if areas_config and len(areas_config) > 1:
+            area_names = "、".join(
+                info.get("name", key) for key, info in self.areas_config.items()
+            )
+            self.system_prompt = f"""あなたは東京都内の主要駅周辺エリア（{area_names}）の地理情報に詳しいアシスタントです。
+提供された情報に基づいて、正確かつ簡潔に回答してください。
+座標情報がある場合は必ず含めてください。
+数値データがある場合は具体的な数字を使って回答してください。
+情報がない場合は「情報がありません」と正直に回答してください。"""
+        else:
+            self.system_prompt = """あなたは渋谷エリアの地理情報に詳しいアシスタントです。
 提供された情報に基づいて、正確かつ簡潔に回答してください。
 座標情報がある場合は必ず含めてください。
 数値データがある場合は具体的な数字を使って回答してください。
@@ -374,19 +406,23 @@ class StructuredRAGSystem:
         self,
         question: str,
         analysis: QuestionAnalysis,
-        k: int = 5
+        k: int = 5,
+        station: Optional[Dict[str, Any]] = None
     ) -> List[Dict[str, Any]]:
         """
         ベクトル検索を実行
-        
+
         Args:
             question: 質問文
             analysis: 質問分析結果
             k: 取得件数
-        
+            station: 基準駅情報（None時はSHIBUYA_STATION）
+
         Returns:
             検索結果リスト
         """
+        station = station or SHIBUYA_STATION
+
         # カテゴリフィルタリングが可能な場合は多めに取得してフィルタ
         if analysis.categories:
             results = self.vectorstore.similarity_search(question, k=k * 2)
@@ -394,14 +430,14 @@ class StructuredRAGSystem:
                 r for r in results
                 if r.metadata.get("category") in analysis.categories
             ][:k]
-            
+
             if filtered:
                 results = filtered
             else:
                 results = results[:k]
         else:
             results = self.vectorstore.similarity_search(question, k=k)
-        
+
         # 結果を辞書形式に変換し、空間情報を追加
         search_results = []
         for r in results:
@@ -413,14 +449,18 @@ class StructuredRAGSystem:
                 "content": r.page_content,
                 "metadata": r.metadata
             }
-            
-            # 空間情報を追加
+
+            # 空間情報を追加（エリア別stationを使用）
             if poi.get("lat") and poi.get("lon"):
-                poi["distance_from_station"] = distance_from_station(poi["lat"], poi["lon"])
-                poi["direction_from_station"] = direction_from_station(poi["lat"], poi["lon"])
-            
+                poi["distance_from_station"] = distance_from_station(
+                    poi["lat"], poi["lon"], station=station
+                )
+                poi["direction_from_station"] = direction_from_station(
+                    poi["lat"], poi["lon"], station=station
+                )
+
             search_results.append(poi)
-        
+
         return search_results
     
     def _execute_aggregation(
@@ -767,6 +807,33 @@ class StructuredRAGSystem:
         
         return "\n".join(context_parts)
     
+    def _get_target_pois_and_station(
+        self,
+        question: str
+    ) -> Tuple[List[Dict[str, Any]], Dict[str, Any], Optional[str]]:
+        """
+        質問文からエリアを特定し、対象POIと基準駅を返す
+
+        Args:
+            question: 質問文
+
+        Returns:
+            (target_pois, target_station, target_area_key)
+        """
+        target_area = detect_target_area(question, self.areas_config)
+
+        if target_area and target_area in self.pois_by_area:
+            target_pois = self.pois_by_area[target_area]
+            target_station = self.areas_config[target_area].get("station", SHIBUYA_STATION)
+        else:
+            target_pois = self.all_pois
+            target_station = SHIBUYA_STATION
+
+        if self.debug:
+            print(f"エリア特定: {target_area or '全エリア'} → POI数: {len(target_pois)}")
+
+        return target_pois, target_station, target_area
+
     def query_with_structured_rag(
         self,
         question: str,
@@ -774,56 +841,66 @@ class StructuredRAGSystem:
     ) -> Dict[str, Any]:
         """
         構造化RAGを使用して質問に回答
-        
+
         Args:
             question: 質問文
             k: ベクトル検索の取得件数
-        
+
         Returns:
             回答と付随情報の辞書
         """
         start_time = time.time()
-        
+
+        # Phase 9-B: エリア特定
+        target_pois, target_station, target_area = self._get_target_pois_and_station(question)
+
         # 質問分析
         analysis = analyze_question(question)
-        
+
         if self.debug:
             print(f"質問分析結果: {analysis.to_dict()}")
-        
-        # ベクトル検索
-        search_results = self._execute_vector_search(question, analysis, k)
-        
+
+        # ベクトル検索（エリア別stationを使用）
+        search_results = self._execute_vector_search(question, analysis, k, station=target_station)
+
+        # 以下の処理はtarget_poisを使用するために一時的にself.all_poisを差し替え
+        original_pois = self.all_pois
+        self.all_pois = target_pois
+
         # 集計処理
         aggregation = None
         if analysis.requires_aggregation:
             aggregation = self._execute_aggregation(question, analysis)
-        
+
         # 比較処理
         comparison = None
         if analysis.requires_comparison:
             comparison = self._execute_comparison(question, analysis)
-        
+
         # 空間フィルタリング
         spatial = None
         if analysis.requires_spatial and (analysis.distance_constraint or analysis.directions):
             spatial = self._execute_spatial_filter(question, analysis)
-        
+
         # Phase 6.2: 近接性検索
         proximity = None
         if analysis.requires_proximity:
             proximity = self._execute_proximity_search(question, analysis)
-        
+
         # Phase 6.2: 感度分析
         sensitivity = None
         if analysis.requires_sensitivity:
             sensitivity = self._execute_sensitivity_analysis(question, analysis)
-        
+
+        # self.all_poisを復元
+        self.all_pois = original_pois
+
         # コンテキスト構築
         context = self._build_context(
             search_results, aggregation, comparison, spatial,
             proximity, sensitivity
         )
-        
+
         # プロンプト構築
         prompt = f"""以下の情報を参考にして、質問に回答してください。
 
@@ -834,12 +911,12 @@ class StructuredRAGSystem:
 
 【回答】
 上記の情報を基に、具体的な数値や場所名を含めて回答します。"""
-        
+
         # 回答生成
         answer = self._generate_response(prompt)
-        
+
         elapsed_time = time.time() - start_time
-        
+
         return {
             "answer": answer,
             "analysis": analysis.to_dict(),
@@ -848,6 +925,7 @@ class StructuredRAGSystem:
             "comparison": comparison,
             "spatial": spatial,
             "context": context,
+            "target_area": target_area,
             "time_ms": int(elapsed_time * 1000)
         }
 
@@ -908,11 +986,18 @@ class StructuredRAGSystem:
         Returns:
             コンテキストテキスト
         """
+        # Phase 9-B: エリア特定
+        target_pois, target_station, target_area = self._get_target_pois_and_station(question)
+
         # 質問分析
         analysis = analyze_question(question)
 
         # ベクトル検索
-        search_results = self._execute_vector_search(question, analysis, k)
+        search_results = self._execute_vector_search(question, analysis, k, station=target_station)
+
+        # target_poisを使用するために一時的にself.all_poisを差し替え
+        original_pois = self.all_pois
+        self.all_pois = target_pois
 
         # 集計処理
         aggregation = None
@@ -938,6 +1023,9 @@ class StructuredRAGSystem:
         sensitivity = None
         if analysis.requires_sensitivity:
             sensitivity = self._execute_sensitivity_analysis(question, analysis)
+
+        # self.all_poisを復元
+        self.all_pois = original_pois
 
         # コンテキスト構築
         context = self._build_context(
@@ -990,18 +1078,20 @@ def create_structured_rag_system(
     tokenizer,
     vectorstore,
     poi_documents: List[Dict[str, Any]],
+    areas_config: Optional[Dict[str, Any]] = None,
     debug: bool = False
 ) -> StructuredRAGSystem:
     """
     StructuredRAGSystemのファクトリ関数
-    
+
     Args:
         model: Hugging Face Transformersモデル
         tokenizer: トークナイザー
         vectorstore: LangChain ChromaDBベクトルストア
         poi_documents: POIドキュメントのリスト
+        areas_config: エリア設定辞書（None時は渋谷単一エリア）
         debug: デバッグモード
-    
+
     Returns:
         StructuredRAGSystemインスタンス
     """
@@ -1016,11 +1106,12 @@ def create_structured_rag_system(
             if hasattr(doc, 'page_content'):
                 poi['content'] = doc.page_content
         all_pois.append(poi)
-    
+
     return StructuredRAGSystem(
         model=model,
         tokenizer=tokenizer,
         vectorstore=vectorstore,
         all_pois=all_pois,
+        areas_config=areas_config,
         debug=debug
     )

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,24 @@ version = 1
 requires-python = ">=3.13"
 
 [[package]]
+name = "accelerate"
+version = "1.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/8e/ac2a9566747a93f8be36ee08532eb0160558b07630a081a6056a9f89bf1d/accelerate-1.12.0.tar.gz", hash = "sha256:70988c352feb481887077d2ab845125024b2a137a5090d6d7a32b57d03a45df6", size = 398399 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/d2/c581486aa6c4fbd7394c23c47b83fa1a919d34194e16944241daf9e762dd/accelerate-1.12.0-py3-none-any.whl", hash = "sha256:3e2091cd341423207e2f084a6654b1efcd250dc326f2a37d6dde446e07cabb11", size = 380935 },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -196,6 +214,22 @@ wheels = [
 ]
 
 [[package]]
+name = "bitsandbytes"
+version = "0.49.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "torch" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/7d/f1fe0992334b18cd8494f89aeec1dcc674635584fcd9f115784fea3a1d05/bitsandbytes-0.49.2-py3-none-macosx_14_0_arm64.whl", hash = "sha256:87be5975edeac5396d699ecbc39dfc47cf2c026daaf2d5852a94368611a6823f", size = 131940 },
+    { url = "https://files.pythonhosted.org/packages/29/71/acff7af06c818664aa87ff73e17a52c7788ad746b72aea09d3cb8e424348/bitsandbytes-0.49.2-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:2fc0830c5f7169be36e60e11f2be067c8f812dfcb829801a8703735842450750", size = 31442815 },
+    { url = "https://files.pythonhosted.org/packages/19/57/3443d6f183436fbdaf5000aac332c4d5ddb056665d459244a5608e98ae92/bitsandbytes-0.49.2-py3-none-manylinux_2_24_x86_64.whl", hash = "sha256:54b771f06e1a3c73af5c7f16ccf0fc23a846052813d4b008d10cb6e017dd1c8c", size = 60651714 },
+    { url = "https://files.pythonhosted.org/packages/b6/d4/501655842ad6771fb077f576d78cbedb5445d15b1c3c91343ed58ca46f0e/bitsandbytes-0.49.2-py3-none-win_amd64.whl", hash = "sha256:2e0ddd09cd778155388023cbe81f00afbb7c000c214caef3ce83386e7144df7d", size = 55372289 },
+]
+
+[[package]]
 name = "build"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -335,6 +369,28 @@ wheels = [
 ]
 
 [[package]]
+name = "cuda-bindings"
+version = "12.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/56/e465c31dc9111be3441a9ba7df1941fe98f4aa6e71e8788a3fb4534ce24d/cuda_bindings-12.9.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:32bdc5a76906be4c61eb98f546a6786c5773a881f3b166486449b5d141e4a39f", size = 11906628 },
+    { url = "https://files.pythonhosted.org/packages/a3/84/1e6be415e37478070aeeee5884c2022713c1ecc735e6d82d744de0252eee/cuda_bindings-12.9.4-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56e0043c457a99ac473ddc926fe0dc4046694d99caef633e92601ab52cbe17eb", size = 11925991 },
+    { url = "https://files.pythonhosted.org/packages/d1/af/6dfd8f2ed90b1d4719bc053ff8940e494640fe4212dc3dd72f383e4992da/cuda_bindings-12.9.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8b72ee72a9cc1b531db31eebaaee5c69a8ec3500e32c6933f2d3b15297b53686", size = 11922703 },
+    { url = "https://files.pythonhosted.org/packages/6c/19/90ac264acc00f6df8a49378eedec9fd2db3061bf9263bf9f39fd3d8377c3/cuda_bindings-12.9.4-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d80bffc357df9988dca279734bc9674c3934a654cab10cadeed27ce17d8635ee", size = 11924658 },
+]
+
+[[package]]
+name = "cuda-pathfinder"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/5e/db279a3bfbd18d59d0598922a3b3c1454908d0969e8372260afec9736376/cuda_pathfinder-1.3.4-py3-none-any.whl", hash = "sha256:fb983f6e0d43af27ef486e14d5989b5f904ef45cedf40538bfdcbffa6bb01fb2", size = 30878 },
+]
+
+[[package]]
 name = "dataclasses-json"
 version = "0.6.7"
 source = { registry = "https://pypi.org/simple" }
@@ -370,6 +426,8 @@ name = "experiments-local-llm"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "accelerate" },
+    { name = "bitsandbytes" },
     { name = "chromadb" },
     { name = "langchain" },
     { name = "langchain-chroma" },
@@ -380,10 +438,15 @@ dependencies = [
     { name = "langgraph" },
     { name = "networkx" },
     { name = "requests" },
+    { name = "sentencepiece" },
+    { name = "torch" },
+    { name = "transformers" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "accelerate", specifier = ">=0.25.0" },
+    { name = "bitsandbytes", specifier = ">=0.41.0" },
     { name = "chromadb", specifier = ">=1.4.1" },
     { name = "langchain", extras = ["all"], specifier = ">=1.2.4" },
     { name = "langchain-chroma", specifier = ">=1.1.0" },
@@ -394,6 +457,9 @@ requires-dist = [
     { name = "langgraph", specifier = ">=0.2.0" },
     { name = "networkx", specifier = ">=3.6.1" },
     { name = "requests", specifier = ">=2.32.5" },
+    { name = "sentencepiece", specifier = ">=0.1.99" },
+    { name = "torch", specifier = ">=2.1.0" },
+    { name = "transformers", specifier = ">=4.36.0" },
 ]
 
 [[package]]
@@ -743,6 +809,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899 },
+]
+
+[[package]]
 name = "jsonpatch"
 version = "1.33"
 source = { registry = "https://pypi.org/simple" }
@@ -1012,6 +1090,58 @@ wheels = [
 ]
 
 [[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622 },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029 },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374 },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980 },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990 },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784 },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588 },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041 },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543 },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113 },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911 },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658 },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066 },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639 },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569 },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284 },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801 },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769 },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642 },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612 },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200 },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973 },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619 },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029 },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408 },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005 },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048 },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821 },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606 },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043 },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747 },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341 },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073 },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661 },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069 },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670 },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598 },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261 },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835 },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733 },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672 },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819 },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426 },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146 },
+]
+
+[[package]]
 name = "marshmallow"
 version = "3.26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1252,6 +1382,140 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/23/12/8b5fc6b9c487a09a7957188e0943c9ff08432c65e34567cabc1623b03a51/numpy-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:5de60946f14ebe15e713a6f22850c2372fa72f4ff9a432ab44aa90edcadaa65a", size = 6152482 },
     { url = "https://files.pythonhosted.org/packages/00/a5/9f8ca5856b8940492fc24fbe13c1bc34d65ddf4079097cf9e53164d094e1/numpy-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:8f085da926c0d491ffff3096f91078cc97ea67e7e6b65e490bc8dcda65663be2", size = 12627117 },
     { url = "https://files.pythonhosted.org/packages/ad/0d/eca3d962f9eef265f01a8e0d20085c6dd1f443cbffc11b6dede81fd82356/numpy-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:6436cffb4f2bf26c974344439439c95e152c9a527013f26b3577be6c2ca64295", size = 10667121 },
+]
+
+[[package]]
+name = "nvidia-cublas-cu12"
+version = "12.8.4.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921 },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621 },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.8.93"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029 },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765 },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu12"
+version = "9.10.2.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467 },
+]
+
+[[package]]
+name = "nvidia-cufft-cu12"
+version = "11.3.3.83"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695 },
+]
+
+[[package]]
+name = "nvidia-cufile-cu12"
+version = "1.13.1.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834 },
+]
+
+[[package]]
+name = "nvidia-curand-cu12"
+version = "10.3.9.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976 },
+]
+
+[[package]]
+name = "nvidia-cusolver-cu12"
+version = "11.7.3.90"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905 },
+]
+
+[[package]]
+name = "nvidia-cusparse-cu12"
+version = "12.5.8.93"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466 },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu12"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691 },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.27.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/89/f7a07dc961b60645dbbf42e80f2bc85ade7feb9a491b11a1e973aa00071f/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457", size = 322348229 },
+]
+
+[[package]]
+name = "nvidia-nvjitlink-cu12"
+version = "12.8.93"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836 },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu12"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/09/6ea3ea725f82e1e76684f0708bbedd871fc96da89945adeba65c3835a64c/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:042f2500f24c021db8a06c5eec2539027d57460e1c1a762055a6554f72c369bd", size = 139103095 },
+]
+
+[[package]]
+name = "nvidia-nvtx-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954 },
 ]
 
 [[package]]
@@ -1566,6 +1830,34 @@ wheels = [
 ]
 
 [[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595 },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082 },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476 },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062 },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893 },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589 },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664 },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087 },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383 },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210 },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228 },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284 },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090 },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859 },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560 },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997 },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972 },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266 },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737 },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617 },
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1869,6 +2161,78 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.1.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/86/07d5056945f9ec4590b518171c4254a5925832eb727b56d3c38a7476f316/regex-2026.1.15.tar.gz", hash = "sha256:164759aa25575cbc0651bef59a0b18353e54300d79ace8084c818ad8ac72b7d5", size = 414811 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/2e/6870bb16e982669b674cce3ee9ff2d1d46ab80528ee6bcc20fb2292efb60/regex-2026.1.15-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e69d0deeb977ffe7ed3d2e4439360089f9c3f217ada608f0f88ebd67afb6385e", size = 489164 },
+    { url = "https://files.pythonhosted.org/packages/dc/67/9774542e203849b0286badf67199970a44ebdb0cc5fb739f06e47ada72f8/regex-2026.1.15-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3601ffb5375de85a16f407854d11cca8fe3f5febbe3ac78fb2866bb220c74d10", size = 291218 },
+    { url = "https://files.pythonhosted.org/packages/b2/87/b0cda79f22b8dee05f774922a214da109f9a4c0eca5da2c9d72d77ea062c/regex-2026.1.15-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4c5ef43b5c2d4114eb8ea424bb8c9cec01d5d17f242af88b2448f5ee81caadbc", size = 288895 },
+    { url = "https://files.pythonhosted.org/packages/3b/6a/0041f0a2170d32be01ab981d6346c83a8934277d82c780d60b127331f264/regex-2026.1.15-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:968c14d4f03e10b2fd960f1d5168c1f0ac969381d3c1fcc973bc45fb06346599", size = 798680 },
+    { url = "https://files.pythonhosted.org/packages/58/de/30e1cfcdbe3e891324aa7568b7c968771f82190df5524fabc1138cb2d45a/regex-2026.1.15-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:56a5595d0f892f214609c9f76b41b7428bed439d98dc961efafdd1354d42baae", size = 864210 },
+    { url = "https://files.pythonhosted.org/packages/64/44/4db2f5c5ca0ccd40ff052ae7b1e9731352fcdad946c2b812285a7505ca75/regex-2026.1.15-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0bf650f26087363434c4e560011f8e4e738f6f3e029b85d4904c50135b86cfa5", size = 912358 },
+    { url = "https://files.pythonhosted.org/packages/79/b6/e6a5665d43a7c42467138c8a2549be432bad22cbd206f5ec87162de74bd7/regex-2026.1.15-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18388a62989c72ac24de75f1449d0fb0b04dfccd0a1a7c1c43af5eb503d890f6", size = 803583 },
+    { url = "https://files.pythonhosted.org/packages/e7/53/7cd478222169d85d74d7437e74750005e993f52f335f7c04ff7adfda3310/regex-2026.1.15-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6d220a2517f5893f55daac983bfa9fe998a7dbcaee4f5d27a88500f8b7873788", size = 775782 },
+    { url = "https://files.pythonhosted.org/packages/ca/b5/75f9a9ee4b03a7c009fe60500fe550b45df94f0955ca29af16333ef557c5/regex-2026.1.15-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c9c08c2fbc6120e70abff5d7f28ffb4d969e14294fb2143b4b5c7d20e46d1714", size = 787978 },
+    { url = "https://files.pythonhosted.org/packages/72/b3/79821c826245bbe9ccbb54f6eadb7879c722fd3e0248c17bfc90bf54e123/regex-2026.1.15-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7ef7d5d4bd49ec7364315167a4134a015f61e8266c6d446fc116a9ac4456e10d", size = 858550 },
+    { url = "https://files.pythonhosted.org/packages/4a/85/2ab5f77a1c465745bfbfcb3ad63178a58337ae8d5274315e2cc623a822fa/regex-2026.1.15-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:6e42844ad64194fa08d5ccb75fe6a459b9b08e6d7296bd704460168d58a388f3", size = 763747 },
+    { url = "https://files.pythonhosted.org/packages/6d/84/c27df502d4bfe2873a3e3a7cf1bdb2b9cc10284d1a44797cf38bed790470/regex-2026.1.15-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:cfecdaa4b19f9ca534746eb3b55a5195d5c95b88cac32a205e981ec0a22b7d31", size = 850615 },
+    { url = "https://files.pythonhosted.org/packages/7d/b7/658a9782fb253680aa8ecb5ccbb51f69e088ed48142c46d9f0c99b46c575/regex-2026.1.15-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:08df9722d9b87834a3d701f3fca570b2be115654dbfd30179f30ab2f39d606d3", size = 789951 },
+    { url = "https://files.pythonhosted.org/packages/fc/2a/5928af114441e059f15b2f63e188bd00c6529b3051c974ade7444b85fcda/regex-2026.1.15-cp313-cp313-win32.whl", hash = "sha256:d426616dae0967ca225ab12c22274eb816558f2f99ccb4a1d52ca92e8baf180f", size = 266275 },
+    { url = "https://files.pythonhosted.org/packages/4f/16/5bfbb89e435897bff28cf0352a992ca719d9e55ebf8b629203c96b6ce4f7/regex-2026.1.15-cp313-cp313-win_amd64.whl", hash = "sha256:febd38857b09867d3ed3f4f1af7d241c5c50362e25ef43034995b77a50df494e", size = 277145 },
+    { url = "https://files.pythonhosted.org/packages/56/c1/a09ff7392ef4233296e821aec5f78c51be5e91ffde0d163059e50fd75835/regex-2026.1.15-cp313-cp313-win_arm64.whl", hash = "sha256:8e32f7896f83774f91499d239e24cebfadbc07639c1494bb7213983842348337", size = 270411 },
+    { url = "https://files.pythonhosted.org/packages/3c/38/0cfd5a78e5c6db00e6782fdae70458f89850ce95baa5e8694ab91d89744f/regex-2026.1.15-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ec94c04149b6a7b8120f9f44565722c7ae31b7a6d2275569d2eefa76b83da3be", size = 492068 },
+    { url = "https://files.pythonhosted.org/packages/50/72/6c86acff16cb7c959c4355826bbf06aad670682d07c8f3998d9ef4fee7cd/regex-2026.1.15-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:40c86d8046915bb9aeb15d3f3f15b6fd500b8ea4485b30e1bbc799dab3fe29f8", size = 292756 },
+    { url = "https://files.pythonhosted.org/packages/4e/58/df7fb69eadfe76526ddfce28abdc0af09ffe65f20c2c90932e89d705153f/regex-2026.1.15-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:726ea4e727aba21643205edad8f2187ec682d3305d790f73b7a51c7587b64bdd", size = 291114 },
+    { url = "https://files.pythonhosted.org/packages/ed/6c/a4011cd1cf96b90d2cdc7e156f91efbd26531e822a7fbb82a43c1016678e/regex-2026.1.15-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1cb740d044aff31898804e7bf1181cc72c03d11dfd19932b9911ffc19a79070a", size = 807524 },
+    { url = "https://files.pythonhosted.org/packages/1d/25/a53ffb73183f69c3e9f4355c4922b76d2840aee160af6af5fac229b6201d/regex-2026.1.15-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05d75a668e9ea16f832390d22131fe1e8acc8389a694c8febc3e340b0f810b93", size = 873455 },
+    { url = "https://files.pythonhosted.org/packages/66/0b/8b47fc2e8f97d9b4a851736f3890a5f786443aa8901061c55f24c955f45b/regex-2026.1.15-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d991483606f3dbec93287b9f35596f41aa2e92b7c2ebbb935b63f409e243c9af", size = 915007 },
+    { url = "https://files.pythonhosted.org/packages/c2/fa/97de0d681e6d26fabe71968dbee06dd52819e9a22fdce5dac7256c31ed84/regex-2026.1.15-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:194312a14819d3e44628a44ed6fea6898fdbecb0550089d84c403475138d0a09", size = 812794 },
+    { url = "https://files.pythonhosted.org/packages/22/38/e752f94e860d429654aa2b1c51880bff8dfe8f084268258adf9151cf1f53/regex-2026.1.15-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fe2fda4110a3d0bc163c2e0664be44657431440722c5c5315c65155cab92f9e5", size = 781159 },
+    { url = "https://files.pythonhosted.org/packages/e9/a7/d739ffaef33c378fc888302a018d7f81080393d96c476b058b8c64fd2b0d/regex-2026.1.15-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:124dc36c85d34ef2d9164da41a53c1c8c122cfb1f6e1ec377a1f27ee81deb794", size = 795558 },
+    { url = "https://files.pythonhosted.org/packages/3e/c4/542876f9a0ac576100fc73e9c75b779f5c31e3527576cfc9cb3009dcc58a/regex-2026.1.15-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:a1774cd1981cd212506a23a14dba7fdeaee259f5deba2df6229966d9911e767a", size = 868427 },
+    { url = "https://files.pythonhosted.org/packages/fc/0f/d5655bea5b22069e32ae85a947aa564912f23758e112cdb74212848a1a1b/regex-2026.1.15-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:b5f7d8d2867152cdb625e72a530d2ccb48a3d199159144cbdd63870882fb6f80", size = 769939 },
+    { url = "https://files.pythonhosted.org/packages/20/06/7e18a4fa9d326daeda46d471a44ef94201c46eaa26dbbb780b5d92cbfdda/regex-2026.1.15-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:492534a0ab925d1db998defc3c302dae3616a2fc3fe2e08db1472348f096ddf2", size = 854753 },
+    { url = "https://files.pythonhosted.org/packages/3b/67/dc8946ef3965e166f558ef3b47f492bc364e96a265eb4a2bb3ca765c8e46/regex-2026.1.15-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c661fc820cfb33e166bf2450d3dadbda47c8d8981898adb9b6fe24e5e582ba60", size = 799559 },
+    { url = "https://files.pythonhosted.org/packages/a5/61/1bba81ff6d50c86c65d9fd84ce9699dd106438ee4cdb105bf60374ee8412/regex-2026.1.15-cp313-cp313t-win32.whl", hash = "sha256:99ad739c3686085e614bf77a508e26954ff1b8f14da0e3765ff7abbf7799f952", size = 268879 },
+    { url = "https://files.pythonhosted.org/packages/e9/5e/cef7d4c5fb0ea3ac5c775fd37db5747f7378b29526cc83f572198924ff47/regex-2026.1.15-cp313-cp313t-win_amd64.whl", hash = "sha256:32655d17905e7ff8ba5c764c43cb124e34a9245e45b83c22e81041e1071aee10", size = 280317 },
+    { url = "https://files.pythonhosted.org/packages/b4/52/4317f7a5988544e34ab57b4bde0f04944c4786128c933fb09825924d3e82/regex-2026.1.15-cp313-cp313t-win_arm64.whl", hash = "sha256:b2a13dd6a95e95a489ca242319d18fc02e07ceb28fa9ad146385194d95b3c829", size = 271551 },
+    { url = "https://files.pythonhosted.org/packages/52/0a/47fa888ec7cbbc7d62c5f2a6a888878e76169170ead271a35239edd8f0e8/regex-2026.1.15-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:d920392a6b1f353f4aa54328c867fec3320fa50657e25f64abf17af054fc97ac", size = 489170 },
+    { url = "https://files.pythonhosted.org/packages/ac/c4/d000e9b7296c15737c9301708e9e7fbdea009f8e93541b6b43bdb8219646/regex-2026.1.15-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:b5a28980a926fa810dbbed059547b02783952e2efd9c636412345232ddb87ff6", size = 291146 },
+    { url = "https://files.pythonhosted.org/packages/f9/b6/921cc61982e538682bdf3bdf5b2c6ab6b34368da1f8e98a6c1ddc503c9cf/regex-2026.1.15-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:621f73a07595d83f28952d7bd1e91e9d1ed7625fb7af0064d3516674ec93a2a2", size = 288986 },
+    { url = "https://files.pythonhosted.org/packages/ca/33/eb7383dde0bbc93f4fb9d03453aab97e18ad4024ac7e26cef8d1f0a2cff0/regex-2026.1.15-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3d7d92495f47567a9b1669c51fc8d6d809821849063d168121ef801bbc213846", size = 799098 },
+    { url = "https://files.pythonhosted.org/packages/27/56/b664dccae898fc8d8b4c23accd853f723bde0f026c747b6f6262b688029c/regex-2026.1.15-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8dd16fba2758db7a3780a051f245539c4451ca20910f5a5e6ea1c08d06d4a76b", size = 864980 },
+    { url = "https://files.pythonhosted.org/packages/16/40/0999e064a170eddd237bae9ccfcd8f28b3aa98a38bf727a086425542a4fc/regex-2026.1.15-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1e1808471fbe44c1a63e5f577a1d5f02fe5d66031dcbdf12f093ffc1305a858e", size = 911607 },
+    { url = "https://files.pythonhosted.org/packages/07/78/c77f644b68ab054e5a674fb4da40ff7bffb2c88df58afa82dbf86573092d/regex-2026.1.15-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0751a26ad39d4f2ade8fe16c59b2bf5cb19eb3d2cd543e709e583d559bd9efde", size = 803358 },
+    { url = "https://files.pythonhosted.org/packages/27/31/d4292ea8566eaa551fafc07797961c5963cf5235c797cc2ae19b85dfd04d/regex-2026.1.15-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0f0c7684c7f9ca241344ff95a1de964f257a5251968484270e91c25a755532c5", size = 775833 },
+    { url = "https://files.pythonhosted.org/packages/ce/b2/cff3bf2fea4133aa6fb0d1e370b37544d18c8350a2fa118c7e11d1db0e14/regex-2026.1.15-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:74f45d170a21df41508cb67165456538425185baaf686281fa210d7e729abc34", size = 788045 },
+    { url = "https://files.pythonhosted.org/packages/8d/99/2cb9b69045372ec877b6f5124bda4eb4253bc58b8fe5848c973f752bc52c/regex-2026.1.15-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f1862739a1ffb50615c0fde6bae6569b5efbe08d98e59ce009f68a336f64da75", size = 859374 },
+    { url = "https://files.pythonhosted.org/packages/09/16/710b0a5abe8e077b1729a562d2f297224ad079f3a66dce46844c193416c8/regex-2026.1.15-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:453078802f1b9e2b7303fb79222c054cb18e76f7bdc220f7530fdc85d319f99e", size = 763940 },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/7585c8e744e40eb3d32f119191969b91de04c073fca98ec14299041f6e7e/regex-2026.1.15-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:a30a68e89e5a218b8b23a52292924c1f4b245cb0c68d1cce9aec9bbda6e2c160", size = 850112 },
+    { url = "https://files.pythonhosted.org/packages/af/d6/43e1dd85df86c49a347aa57c1f69d12c652c7b60e37ec162e3096194a278/regex-2026.1.15-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9479cae874c81bf610d72b85bb681a94c95722c127b55445285fb0e2c82db8e1", size = 789586 },
+    { url = "https://files.pythonhosted.org/packages/93/38/77142422f631e013f316aaae83234c629555729a9fbc952b8a63ac91462a/regex-2026.1.15-cp314-cp314-win32.whl", hash = "sha256:d639a750223132afbfb8f429c60d9d318aeba03281a5f1ab49f877456448dcf1", size = 271691 },
+    { url = "https://files.pythonhosted.org/packages/4a/a9/ab16b4649524ca9e05213c1cdbb7faa85cc2aa90a0230d2f796cbaf22736/regex-2026.1.15-cp314-cp314-win_amd64.whl", hash = "sha256:4161d87f85fa831e31469bfd82c186923070fc970b9de75339b68f0c75b51903", size = 280422 },
+    { url = "https://files.pythonhosted.org/packages/be/2a/20fd057bf3521cb4791f69f869635f73e0aaf2b9ad2d260f728144f9047c/regex-2026.1.15-cp314-cp314-win_arm64.whl", hash = "sha256:91c5036ebb62663a6b3999bdd2e559fd8456d17e2b485bf509784cd31a8b1705", size = 273467 },
+    { url = "https://files.pythonhosted.org/packages/ad/77/0b1e81857060b92b9cad239104c46507dd481b3ff1fa79f8e7f865aae38a/regex-2026.1.15-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ee6854c9000a10938c79238de2379bea30c82e4925a371711af45387df35cab8", size = 492073 },
+    { url = "https://files.pythonhosted.org/packages/70/f3/f8302b0c208b22c1e4f423147e1913fd475ddd6230565b299925353de644/regex-2026.1.15-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2c2b80399a422348ce5de4fe40c418d6299a0fa2803dd61dc0b1a2f28e280fcf", size = 292757 },
+    { url = "https://files.pythonhosted.org/packages/bf/f0/ef55de2460f3b4a6da9d9e7daacd0cb79d4ef75c64a2af316e68447f0df0/regex-2026.1.15-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:dca3582bca82596609959ac39e12b7dad98385b4fefccb1151b937383cec547d", size = 291122 },
+    { url = "https://files.pythonhosted.org/packages/cf/55/bb8ccbacabbc3a11d863ee62a9f18b160a83084ea95cdfc5d207bfc3dd75/regex-2026.1.15-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef71d476caa6692eea743ae5ea23cde3260677f70122c4d258ca952e5c2d4e84", size = 807761 },
+    { url = "https://files.pythonhosted.org/packages/8f/84/f75d937f17f81e55679a0509e86176e29caa7298c38bd1db7ce9c0bf6075/regex-2026.1.15-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c243da3436354f4af6c3058a3f81a97d47ea52c9bd874b52fd30274853a1d5df", size = 873538 },
+    { url = "https://files.pythonhosted.org/packages/b8/d9/0da86327df70349aa8d86390da91171bd3ca4f0e7c1d1d453a9c10344da3/regex-2026.1.15-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8355ad842a7c7e9e5e55653eade3b7d1885ba86f124dd8ab1f722f9be6627434", size = 915066 },
+    { url = "https://files.pythonhosted.org/packages/2a/5e/f660fb23fc77baa2a61aa1f1fe3a4eea2bbb8a286ddec148030672e18834/regex-2026.1.15-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f192a831d9575271a22d804ff1a5355355723f94f31d9eef25f0d45a152fdc1a", size = 812938 },
+    { url = "https://files.pythonhosted.org/packages/69/33/a47a29bfecebbbfd1e5cd3f26b28020a97e4820f1c5148e66e3b7d4b4992/regex-2026.1.15-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:166551807ec20d47ceaeec380081f843e88c8949780cd42c40f18d16168bed10", size = 781314 },
+    { url = "https://files.pythonhosted.org/packages/65/ec/7ec2bbfd4c3f4e494a24dec4c6943a668e2030426b1b8b949a6462d2c17b/regex-2026.1.15-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f9ca1cbdc0fbfe5e6e6f8221ef2309988db5bcede52443aeaee9a4ad555e0dac", size = 795652 },
+    { url = "https://files.pythonhosted.org/packages/46/79/a5d8651ae131fe27d7c521ad300aa7f1c7be1dbeee4d446498af5411b8a9/regex-2026.1.15-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b30bcbd1e1221783c721483953d9e4f3ab9c5d165aa709693d3f3946747b1aea", size = 868550 },
+    { url = "https://files.pythonhosted.org/packages/06/b7/25635d2809664b79f183070786a5552dd4e627e5aedb0065f4e3cf8ee37d/regex-2026.1.15-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:2a8d7b50c34578d0d3bf7ad58cde9652b7d683691876f83aedc002862a35dc5e", size = 769981 },
+    { url = "https://files.pythonhosted.org/packages/16/8b/fc3fcbb2393dcfa4a6c5ffad92dc498e842df4581ea9d14309fcd3c55fb9/regex-2026.1.15-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:9d787e3310c6a6425eb346be4ff2ccf6eece63017916fd77fe8328c57be83521", size = 854780 },
+    { url = "https://files.pythonhosted.org/packages/d0/38/dde117c76c624713c8a2842530be9c93ca8b606c0f6102d86e8cd1ce8bea/regex-2026.1.15-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:619843841e220adca114118533a574a9cd183ed8a28b85627d2844c500a2b0db", size = 799778 },
+    { url = "https://files.pythonhosted.org/packages/e3/0d/3a6cfa9ae99606afb612d8fb7a66b245a9d5ff0f29bb347c8a30b6ad561b/regex-2026.1.15-cp314-cp314t-win32.whl", hash = "sha256:e90b8db97f6f2c97eb045b51a6b2c5ed69cedd8392459e0642d4199b94fabd7e", size = 274667 },
+    { url = "https://files.pythonhosted.org/packages/5b/b2/297293bb0742fd06b8d8e2572db41a855cdf1cae0bf009b1cb74fe07e196/regex-2026.1.15-cp314-cp314t-win_amd64.whl", hash = "sha256:5ef19071f4ac9f0834793af85bd04a920b4407715624e40cb7a0631a11137cdf", size = 284386 },
+    { url = "https://files.pythonhosted.org/packages/95/e4/a3b9480c78cf8ee86626cb06f8d931d74d775897d44201ccb813097ae697/regex-2026.1.15-cp314-cp314t-win_arm64.whl", hash = "sha256:ca89c5e596fc05b015f27561b3793dc2fa0917ea0d7507eebb448efd35274a70", size = 274837 },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -2000,6 +2364,77 @@ wheels = [
 ]
 
 [[package]]
+name = "safetensors"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/9c/6e74567782559a63bd040a236edca26fd71bc7ba88de2ef35d75df3bca5e/safetensors-0.7.0.tar.gz", hash = "sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0", size = 200878 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/47/aef6c06649039accf914afef490268e1067ed82be62bcfa5b7e886ad15e8/safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517", size = 467781 },
+    { url = "https://files.pythonhosted.org/packages/e8/00/374c0c068e30cd31f1e1b46b4b5738168ec79e7689ca82ee93ddfea05109/safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57", size = 447058 },
+    { url = "https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07d91d0c92a31200f25351f4acb2bc6aff7f48094e13ebb1d0fb995b54b6542", size = 491748 },
+    { url = "https://files.pythonhosted.org/packages/ae/33/1debbbb70e4791dde185edb9413d1fe01619255abb64b300157d7f15dddd/safetensors-0.7.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8469155f4cb518bafb4acf4865e8bb9d6804110d2d9bdcaa78564b9fd841e104", size = 503881 },
+    { url = "https://files.pythonhosted.org/packages/8e/1c/40c2ca924d60792c3be509833df711b553c60effbd91da6f5284a83f7122/safetensors-0.7.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54bef08bf00a2bff599982f6b08e8770e09cc012d7bba00783fc7ea38f1fb37d", size = 623463 },
+    { url = "https://files.pythonhosted.org/packages/9b/3a/13784a9364bd43b0d61eef4bea2845039bc2030458b16594a1bd787ae26e/safetensors-0.7.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:42cb091236206bb2016d245c377ed383aa7f78691748f3bb6ee1bfa51ae2ce6a", size = 532855 },
+    { url = "https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac7252938f0696ddea46f5e855dd3138444e82236e3be475f54929f0c510d48", size = 507152 },
+    { url = "https://files.pythonhosted.org/packages/3c/a8/4b45e4e059270d17af60359713ffd83f97900d45a6afa73aaa0d737d48b6/safetensors-0.7.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1d060c70284127fa805085d8f10fbd0962792aed71879d00864acda69dbab981", size = 541856 },
+    { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060 },
+    { url = "https://files.pythonhosted.org/packages/11/f5/57644a2ff08dc6325816ba7217e5095f17269dada2554b658442c66aed51/safetensors-0.7.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:672132907fcad9f2aedcb705b2d7b3b93354a2aec1b2f706c4db852abe338f85", size = 771715 },
+    { url = "https://files.pythonhosted.org/packages/86/31/17883e13a814bd278ae6e266b13282a01049b0c81341da7fd0e3e71a80a3/safetensors-0.7.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:5d72abdb8a4d56d4020713724ba81dac065fedb7f3667151c4a637f1d3fb26c0", size = 714377 },
+    { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368 },
+    { url = "https://files.pythonhosted.org/packages/05/e5/cb4b713c8a93469e3c5be7c3f8d77d307e65fe89673e731f5c2bfd0a9237/safetensors-0.7.0-cp38-abi3-win32.whl", hash = "sha256:c74af94bf3ac15ac4d0f2a7c7b4663a15f8c2ab15ed0fc7531ca61d0835eccba", size = 326423 },
+    { url = "https://files.pythonhosted.org/packages/5d/e6/ec8471c8072382cb91233ba7267fd931219753bb43814cbc71757bfd4dab/safetensors-0.7.0-cp38-abi3-win_amd64.whl", hash = "sha256:d1239932053f56f3456f32eb9625590cc7582e905021f94636202a864d470755", size = 341380 },
+]
+
+[[package]]
+name = "sentencepiece"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/15/2e7a025fc62d764b151ae6d0f2a92f8081755ebe8d4a64099accc6f77ba6/sentencepiece-0.2.1.tar.gz", hash = "sha256:8138cec27c2f2282f4a34d9a016e3374cd40e5c6e9cb335063db66a0a3b71fad", size = 3228515 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/4a/85fbe1706d4d04a7e826b53f327c4b80f849cf1c7b7c5e31a20a97d8f28b/sentencepiece-0.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:dcd8161eee7b41aae57ded06272905dbd680a0a04b91edd0f64790c796b2f706", size = 1943150 },
+    { url = "https://files.pythonhosted.org/packages/c2/83/4cfb393e287509fc2155480b9d184706ef8d9fa8cbf5505d02a5792bf220/sentencepiece-0.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c6c8f42949f419ff8c7e9960dbadcfbc982d7b5efc2f6748210d3dd53a7de062", size = 1325651 },
+    { url = "https://files.pythonhosted.org/packages/8d/de/5a007fb53b1ab0aafc69d11a5a3dd72a289d5a3e78dcf2c3a3d9b14ffe93/sentencepiece-0.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:097f3394e99456e9e4efba1737c3749d7e23563dd1588ce71a3d007f25475fff", size = 1253641 },
+    { url = "https://files.pythonhosted.org/packages/2c/d2/f552be5928105588f4f4d66ee37dd4c61460d8097e62d0e2e0eec41bc61d/sentencepiece-0.2.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d7b670879c370d350557edabadbad1f6561a9e6968126e6debca4029e5547820", size = 1316271 },
+    { url = "https://files.pythonhosted.org/packages/96/df/0cfe748ace5485be740fed9476dee7877f109da32ed0d280312c94ec259f/sentencepiece-0.2.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7f0fd2f2693309e6628aeeb2e2faf6edd221134dfccac3308ca0de01f8dab47", size = 1387882 },
+    { url = "https://files.pythonhosted.org/packages/ac/dd/f7774d42a881ced8e1739f393ab1e82ece39fc9abd4779e28050c2e975b5/sentencepiece-0.2.1-cp313-cp313-win32.whl", hash = "sha256:92b3816aa2339355fda2c8c4e021a5de92180b00aaccaf5e2808972e77a4b22f", size = 999541 },
+    { url = "https://files.pythonhosted.org/packages/dd/e9/932b9eae6fd7019548321eee1ab8d5e3b3d1294df9d9a0c9ac517c7b636d/sentencepiece-0.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:10ed3dab2044c47f7a2e7b4969b0c430420cdd45735d78c8f853191fa0e3148b", size = 1054669 },
+    { url = "https://files.pythonhosted.org/packages/c9/3a/76488a00ea7d6931689cda28726a1447d66bf1a4837943489314593d5596/sentencepiece-0.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac650534e2251083c5f75dde4ff28896ce7c8904133dc8fef42780f4d5588fcd", size = 1033922 },
+    { url = "https://files.pythonhosted.org/packages/4a/b6/08fe2ce819e02ccb0296f4843e3f195764ce9829cbda61b7513f29b95718/sentencepiece-0.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8dd4b477a7b069648d19363aad0cab9bad2f4e83b2d179be668efa672500dc94", size = 1946052 },
+    { url = "https://files.pythonhosted.org/packages/ab/d9/1ea0e740591ff4c6fc2b6eb1d7510d02f3fb885093f19b2f3abd1363b402/sentencepiece-0.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0c0f672da370cc490e4c59d89e12289778310a0e71d176c541e4834759e1ae07", size = 1327408 },
+    { url = "https://files.pythonhosted.org/packages/99/7e/1fb26e8a21613f6200e1ab88824d5d203714162cf2883248b517deb500b7/sentencepiece-0.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ad8493bea8432dae8d6830365352350f3b4144415a1d09c4c8cb8d30cf3b6c3c", size = 1254857 },
+    { url = "https://files.pythonhosted.org/packages/bc/85/c72fd1f3c7a6010544d6ae07f8ddb38b5e2a7e33bd4318f87266c0bbafbf/sentencepiece-0.2.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b81a24733726e3678d2db63619acc5a8dccd074f7aa7a54ecd5ca33ca6d2d596", size = 1315722 },
+    { url = "https://files.pythonhosted.org/packages/4a/e8/661e5bd82a8aa641fd6c1020bd0e890ef73230a2b7215ddf9c8cd8e941c2/sentencepiece-0.2.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0a81799d0a68d618e89063fb423c3001a034c893069135ffe51fee439ae474d6", size = 1387452 },
+    { url = "https://files.pythonhosted.org/packages/99/5e/ae66c361023a470afcbc1fbb8da722c72ea678a2fcd9a18f1a12598c7501/sentencepiece-0.2.1-cp313-cp313t-win32.whl", hash = "sha256:89a3ea015517c42c0341d0d962f3e6aaf2cf10d71b1932d475c44ba48d00aa2b", size = 1002501 },
+    { url = "https://files.pythonhosted.org/packages/c1/03/d332828c4ff764e16c1b56c2c8f9a33488bbe796b53fb6b9c4205ddbf167/sentencepiece-0.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:33f068c9382dc2e7c228eedfd8163b52baa86bb92f50d0488bf2b7da7032e484", size = 1057555 },
+    { url = "https://files.pythonhosted.org/packages/88/14/5aee0bf0864df9bd82bd59e7711362908e4935e3f9cdc1f57246b5d5c9b9/sentencepiece-0.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:b3616ad246f360e52c85781e47682d31abfb6554c779e42b65333d4b5f44ecc0", size = 1036042 },
+    { url = "https://files.pythonhosted.org/packages/24/9c/89eb8b2052f720a612478baf11c8227dcf1dc28cd4ea4c0c19506b5af2a2/sentencepiece-0.2.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:5d0350b686c320068702116276cfb26c066dc7e65cfef173980b11bb4d606719", size = 1943147 },
+    { url = "https://files.pythonhosted.org/packages/82/0b/a1432bc87f97c2ace36386ca23e8bd3b91fb40581b5e6148d24b24186419/sentencepiece-0.2.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:c7f54a31cde6fa5cb030370566f68152a742f433f8d2be458463d06c208aef33", size = 1325624 },
+    { url = "https://files.pythonhosted.org/packages/ea/99/bbe054ebb5a5039457c590e0a4156ed073fb0fe9ce4f7523404dd5b37463/sentencepiece-0.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c83b85ab2d6576607f31df77ff86f28182be4a8de6d175d2c33ca609925f5da1", size = 1253670 },
+    { url = "https://files.pythonhosted.org/packages/19/ad/d5c7075f701bd97971d7c2ac2904f227566f51ef0838dfbdfdccb58cd212/sentencepiece-0.2.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1855f57db07b51fb51ed6c9c452f570624d2b169b36f0f79ef71a6e6c618cd8b", size = 1316247 },
+    { url = "https://files.pythonhosted.org/packages/fb/03/35fbe5f3d9a7435eebd0b473e09584bd3cc354ce118b960445b060d33781/sentencepiece-0.2.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01e6912125cb45d3792f530a4d38f8e21bf884d6b4d4ade1b2de5cf7a8d2a52b", size = 1387894 },
+    { url = "https://files.pythonhosted.org/packages/dc/aa/956ef729aafb6c8f9c443104c9636489093bb5c61d6b90fc27aa1a865574/sentencepiece-0.2.1-cp314-cp314-win32.whl", hash = "sha256:c415c9de1447e0a74ae3fdb2e52f967cb544113a3a5ce3a194df185cbc1f962f", size = 1096698 },
+    { url = "https://files.pythonhosted.org/packages/b8/cb/fe400d8836952cc535c81a0ce47dc6875160e5fedb71d2d9ff0e9894c2a6/sentencepiece-0.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:881b2e44b14fc19feade3cbed314be37de639fc415375cefaa5bc81a4be137fd", size = 1155115 },
+    { url = "https://files.pythonhosted.org/packages/32/89/047921cf70f36c7b6b6390876b2399b3633ab73b8d0cb857e5a964238941/sentencepiece-0.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:2005242a16d2dc3ac5fe18aa7667549134d37854823df4c4db244752453b78a8", size = 1133890 },
+    { url = "https://files.pythonhosted.org/packages/a1/11/5b414b9fae6255b5fb1e22e2ed3dc3a72d3a694e5703910e640ac78346bb/sentencepiece-0.2.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:a19adcec27c524cb7069a1c741060add95f942d1cbf7ad0d104dffa0a7d28a2b", size = 1946081 },
+    { url = "https://files.pythonhosted.org/packages/77/eb/7a5682bb25824db8545f8e5662e7f3e32d72a508fdce086029d89695106b/sentencepiece-0.2.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:e37e4b4c4a11662b5db521def4e44d4d30ae69a1743241412a93ae40fdcab4bb", size = 1327406 },
+    { url = "https://files.pythonhosted.org/packages/03/b0/811dae8fb9f2784e138785d481469788f2e0d0c109c5737372454415f55f/sentencepiece-0.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:477c81505db072b3ab627e7eab972ea1025331bd3a92bacbf798df2b75ea86ec", size = 1254846 },
+    { url = "https://files.pythonhosted.org/packages/ef/23/195b2e7ec85ebb6a547969f60b723c7aca5a75800ece6cc3f41da872d14e/sentencepiece-0.2.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:010f025a544ef770bb395091d57cb94deb9652d8972e0d09f71d85d5a0816c8c", size = 1315721 },
+    { url = "https://files.pythonhosted.org/packages/7e/aa/553dbe4178b5f23eb28e59393dddd64186178b56b81d9b8d5c3ff1c28395/sentencepiece-0.2.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:733e59ff1794d26db706cd41fc2d7ca5f6c64a820709cb801dc0ea31780d64ab", size = 1387458 },
+    { url = "https://files.pythonhosted.org/packages/66/7c/08ff0012507297a4dd74a5420fdc0eb9e3e80f4e88cab1538d7f28db303d/sentencepiece-0.2.1-cp314-cp314t-win32.whl", hash = "sha256:d3233770f78e637dc8b1fda2cd7c3b99ec77e7505041934188a4e7fe751de3b0", size = 1099765 },
+    { url = "https://files.pythonhosted.org/packages/91/d5/2a69e1ce15881beb9ddfc7e3f998322f5cedcd5e4d244cb74dade9441663/sentencepiece-0.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:5e4366c97b68218fd30ea72d70c525e6e78a6c0a88650f57ac4c43c63b234a9d", size = 1157807 },
+    { url = "https://files.pythonhosted.org/packages/f3/16/54f611fcfc2d1c46cbe3ec4169780b2cfa7cf63708ef2b71611136db7513/sentencepiece-0.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:105e36e75cbac1292642045458e8da677b2342dcd33df503e640f0b457cb6751", size = 1136264 },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/f3/748f4d6f65d1756b9ae577f329c951cda23fb900e4de9f70900ced962085/setuptools-82.0.0.tar.gz", hash = "sha256:22e0a2d69474c6ae4feb01951cb69d515ed23728cf96d05513d36e42b62b37cb", size = 1144893 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/c6/76dc613121b793286a3f91621d7b75a2b493e0390ddca50f11993eadf192/setuptools-82.0.0-py3-none-any.whl", hash = "sha256:70b18734b607bd1da571d097d236cfcfacaf01de45717d59e6e04b96877532e0", size = 1003468 },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2094,6 +2529,56 @@ wheels = [
 ]
 
 [[package]]
+name = "torch"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-bindings", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254 },
+    { url = "https://files.pythonhosted.org/packages/c9/6f/f2e91e34e3fcba2e3fc8d8f74e7d6c22e74e480bbd1db7bc8900fdf3e95c/torch-2.10.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:5c4d217b14741e40776dd7074d9006fd28b8a97ef5654db959d8635b2fe5f29b", size = 146004247 },
+    { url = "https://files.pythonhosted.org/packages/98/fb/5160261aeb5e1ee12ee95fe599d0541f7c976c3701d607d8fc29e623229f/torch-2.10.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6b71486353fce0f9714ca0c9ef1c850a2ae766b409808acd58e9678a3edb7738", size = 915716445 },
+    { url = "https://files.pythonhosted.org/packages/6a/16/502fb1b41e6d868e8deb5b0e3ae926bbb36dab8ceb0d1b769b266ad7b0c3/torch-2.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2ee399c644dc92ef7bc0d4f7e74b5360c37cdbe7c5ba11318dda49ffac2bc57", size = 113757050 },
+    { url = "https://files.pythonhosted.org/packages/1a/0b/39929b148f4824bc3ad6f9f72a29d4ad865bcf7ebfc2fa67584773e083d2/torch-2.10.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:3202429f58309b9fa96a614885eace4b7995729f44beb54d3e4a47773649d382", size = 79851305 },
+    { url = "https://files.pythonhosted.org/packages/d8/14/21fbce63bc452381ba5f74a2c0a959fdf5ad5803ccc0c654e752e0dbe91a/torch-2.10.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:aae1b29cd68e50a9397f5ee897b9c24742e9e306f88a807a27d617f07adb3bd8", size = 146005472 },
+    { url = "https://files.pythonhosted.org/packages/54/fd/b207d1c525cb570ef47f3e9f836b154685011fce11a2f444ba8a4084d042/torch-2.10.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:6021db85958db2f07ec94e1bc77212721ba4920c12a18dc552d2ae36a3eb163f", size = 915612644 },
+    { url = "https://files.pythonhosted.org/packages/36/53/0197f868c75f1050b199fe58f9bf3bf3aecac9b4e85cc9c964383d745403/torch-2.10.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ff43db38af76fda183156153983c9a096fc4c78d0cd1e07b14a2314c7f01c2c8", size = 113997015 },
+    { url = "https://files.pythonhosted.org/packages/0e/13/e76b4d9c160e89fff48bf16b449ea324bda84745d2ab30294c37c2434c0d/torch-2.10.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:cdf2a523d699b70d613243211ecaac14fe9c5df8a0b0a9c02add60fb2a413e0f", size = 79498248 },
+    { url = "https://files.pythonhosted.org/packages/4f/93/716b5ac0155f1be70ed81bacc21269c3ece8dba0c249b9994094110bfc51/torch-2.10.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:bf0d9ff448b0218e0433aeb198805192346c4fd659c852370d5cc245f602a06a", size = 79464992 },
+    { url = "https://files.pythonhosted.org/packages/69/2b/51e663ff190c9d16d4a8271203b71bc73a16aa7619b9f271a69b9d4a936b/torch-2.10.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:233aed0659a2503b831d8a67e9da66a62c996204c0bba4f4c442ccc0c68a3f60", size = 146018567 },
+    { url = "https://files.pythonhosted.org/packages/5e/cd/4b95ef7f293b927c283db0b136c42be91c8ec6845c44de0238c8c23bdc80/torch-2.10.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:682497e16bdfa6efeec8cde66531bc8d1fbbbb4d8788ec6173c089ed3cc2bfe5", size = 915721646 },
+    { url = "https://files.pythonhosted.org/packages/56/97/078a007208f8056d88ae43198833469e61a0a355abc0b070edd2c085eb9a/torch-2.10.0-cp314-cp314-win_amd64.whl", hash = "sha256:6528f13d2a8593a1a412ea07a99812495bec07e9224c28b2a25c0a30c7da025c", size = 113752373 },
+    { url = "https://files.pythonhosted.org/packages/d8/94/71994e7d0d5238393df9732fdab607e37e2b56d26a746cb59fdb415f8966/torch-2.10.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f5ab4ba32383061be0fb74bda772d470140a12c1c3b58a0cfbf3dae94d164c28", size = 79850324 },
+    { url = "https://files.pythonhosted.org/packages/e2/65/1a05346b418ea8ccd10360eef4b3e0ce688fba544e76edec26913a8d0ee0/torch-2.10.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:716b01a176c2a5659c98f6b01bf868244abdd896526f1c692712ab36dbaf9b63", size = 146006482 },
+    { url = "https://files.pythonhosted.org/packages/1d/b9/5f6f9d9e859fc3235f60578fa64f52c9c6e9b4327f0fe0defb6de5c0de31/torch-2.10.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:d8f5912ba938233f86361e891789595ff35ca4b4e2ac8fe3670895e5976731d6", size = 915613050 },
+    { url = "https://files.pythonhosted.org/packages/66/4d/35352043ee0eaffdeff154fad67cd4a31dbed7ff8e3be1cc4549717d6d51/torch-2.10.0-cp314-cp314t-win_amd64.whl", hash = "sha256:71283a373f0ee2c89e0f0d5f446039bdabe8dbc3c9ccf35f0f784908b0acd185", size = 113995816 },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2103,6 +2588,37 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540 },
+]
+
+[[package]]
+name = "transformers"
+version = "5.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer-slim" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/7e/8a0c57d562015e5b16c97c1f0b8e0e92ead2c7c20513225dc12c2043ba9f/transformers-5.2.0.tar.gz", hash = "sha256:0088b8b46ccc9eff1a1dca72b5d618a5ee3b1befc3e418c9512b35dea9f9a650", size = 8618176 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/93/79754b0ca486e556c2b95d4f5afc66aaf4b260694f3d6e1b51da2d036691/transformers-5.2.0-py3-none-any.whl", hash = "sha256:9ecaf243dc45bee11a7d93f8caf03746accc0cb069181bbf4ad8566c53e854b4", size = 10403304 },
+]
+
+[[package]]
+name = "triton"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450 },
+    { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296 },
+    { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063 },
+    { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Issue #11 の実装: 4つのRAGシステムを渋谷単一エリアから4エリア（渋谷・新宿・池袋・東京）に対応させ、Agentic RAGの中国語混入問題を対策。

- **agent_prompts.py**: システムプロンプトを4エリア対応に汎用化、ReActメタ言語を日本語化（Thought→思考, Action→行動, Final Answer→最終回答）
- **agent_tools.py**: 全16ツールにarea引数追加、`format_tool_output_japanese()`でJSON出力を日本語自然文に変換（中国語混入対策の主要施策）
- **structured_rag_system.py**: `areas_config`対応、`detect_target_area()`によるエリア自動検出
- **graph_rag_system.py**: エリア別グラフ構築、`_select_graph_and_indices()`追加
- **agentic_rag_system.py**: 日本語/英語両方のReActパーサー対応、`areas_config`伝播
- **adaptive_rag_system.py**: `areas_config`伝播、動的システムプロンプト生成

**後方互換性**: 全システムで`areas_config=None`時は渋谷単一エリア動作を維持。

### 中国語混入対策（Agentic RAG）

Qwen2.5がJSON出力やEnglishメタ言語に反応して中国語で回答する問題への対策:
1. **ツール出力日本語化** (50%寄与): `format_tool_output_japanese()`で全ツールの出力をJSON→日本語自然文に変換
2. **ReActメタ言語日本語化** (30%寄与): Thought/Action/Final Answer → 思考/行動/最終回答

## Test plan

- [x] agent_prompts.py: システムプロンプト汎用化 + ReAct日本語化のアサーション
- [x] agent_tools.py: format_tool_output_japanese 16ツール対応 + エラーハンドリング
- [x] structured_rag_system.py: コンストラクタ・ファクトリ関数のシグネチャ確認
- [x] graph_rag_system.py: コンストラクタシグネチャ確認
- [x] adaptive_rag_system.py: コンストラクタシグネチャ確認
- [x] agentic_rag_system.py: 日本語/英語ReActパーサー + areas_config対応確認
- [ ] Google Colab統合テスト（Issue #12で実施予定）

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)